### PR TITLE
Refactor Pixel Class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
     tile.cpp
     pixel.cpp
     update_functions.cpp
+    timer.cpp
 
     graphics/window.cpp
     graphics/shader.cpp

--- a/src/graphics/window.cpp
+++ b/src/graphics/window.cpp
@@ -188,10 +188,14 @@ void window::clear() const
 	glClearColor(0.0, 0.0, 0.0, 1.0);
 }
 
-void window::swap_and_poll()
+void window::poll_events()
+{
+    glfwPollEvents();
+}
+
+void window::swap_buffers()
 {
     glfwSwapBuffers(d_data.native_window);
-    glfwPollEvents();
 }
 
 bool window::is_running() const

--- a/src/graphics/window.h
+++ b/src/graphics/window.h
@@ -39,7 +39,8 @@ public:
     ~window();
 
     void clear() const;
-    void swap_and_poll();
+    void swap_buffers();
+    void poll_events();
 
     bool is_running() const;
 

--- a/src/overloaded.hpp
+++ b/src/overloaded.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace anzu {
+
+template <typename... Ts>
+struct overloaded : Ts...
+{
+    using Ts::operator()...;
+};
+
+}

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -7,7 +7,7 @@ namespace sand {
 pixel pixel::air()
 {
     return {
-        .data = empty{},
+        .data = std::monostate{},
         .colour = {
             44.0f / 256.0f,
             58.0f / 256.0f,

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -7,6 +7,7 @@ namespace sand {
 pixel pixel::air()
 {
     return {
+        .data = empty{},
         .type = pixel_type::air,
         .colour = {
             44.0f / 256.0f,
@@ -20,6 +21,7 @@ pixel pixel::air()
 pixel pixel::sand()
 {
     return {
+        .data = movable_solid{},
         .type = pixel_type::sand,
         .colour = {
             (248.0f + (rand() % 20) - 10) / 256.0f,
@@ -33,6 +35,7 @@ pixel pixel::sand()
 pixel pixel::rock()
 {
     return {
+        .data = static_solid{},
         .type = pixel_type::rock,
         .colour = {
             (200.0f + (rand() % 20) - 10) / 256.0f,
@@ -46,8 +49,9 @@ pixel pixel::rock()
 pixel pixel::water()
 {
     return {
-        pixel_type::water,
-        {
+        .data = liquid{},
+        .type = pixel_type::water,
+        .colour = {
             (27.0f  + (rand() % 20) - 10) / 256.0f,
             (156.0f + (rand() % 20) - 10) / 256.0f,
             (252.0f + (rand() % 20) - 10) / 256.0f,
@@ -59,6 +63,7 @@ pixel pixel::water()
 pixel pixel::red_sand()
 {
     return {
+        .data = movable_solid{},
         .type = pixel_type::sand,
         .colour = {
             (254.0f + (rand() % 20) - 10) / 256.0f,
@@ -67,45 +72,6 @@ pixel pixel::red_sand()
             1.0
         }
     };
-}
-
-auto make_sand() -> pixel2
-{
-    auto ret = pixel2{};
-    auto& data = ret.data.emplace<movable_solid>();
-    ret.colour = {
-        (248.0f + (rand() % 20) - 10) / 256.0f,
-        (239.0f + (rand() % 20) - 10) / 256.0f,
-        (186.0f + (rand() % 20) - 10) / 256.0f,
-        1.0
-    };
-    return ret;
-}
-
-auto make_water() -> pixel2
-{
-    auto ret = pixel2{};
-    auto& data = ret.data.emplace<liquid>();
-    ret.colour = {
-        (27.0f  + (rand() % 20) - 10) / 256.0f,
-        (156.0f + (rand() % 20) - 10) / 256.0f,
-        (252.0f + (rand() % 20) - 10) / 256.0f,
-        1.0
-    };
-    return ret;
-}
-
-auto make_stone() -> pixel2
-{
-    auto ret = pixel2{};
-    auto& data = ret.data.emplace<static_solid>();
-    ret.colour = {
-        (200.0f + (rand() % 20) - 10) / 256.0f,
-        (200.0f + (rand() % 20) - 10) / 256.0f,
-        (200.0f + (rand() % 20) - 10) / 256.0f,
-        1.0
-    };
-    return ret;
 }
 
 

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -69,4 +69,44 @@ pixel pixel::red_sand()
     };
 }
 
+auto make_sand() -> pixel2
+{
+    auto ret = pixel2{};
+    auto& data = ret.data.emplace<movable_solid>();
+    ret.colour = {
+        (248.0f + (rand() % 20) - 10) / 256.0f,
+        (239.0f + (rand() % 20) - 10) / 256.0f,
+        (186.0f + (rand() % 20) - 10) / 256.0f,
+        1.0
+    };
+    return ret;
+}
+
+auto make_water() -> pixel2
+{
+    auto ret = pixel2{};
+    auto& data = ret.data.emplace<liquid>();
+    ret.colour = {
+        (27.0f  + (rand() % 20) - 10) / 256.0f,
+        (156.0f + (rand() % 20) - 10) / 256.0f,
+        (252.0f + (rand() % 20) - 10) / 256.0f,
+        1.0
+    };
+    return ret;
+}
+
+auto make_stone() -> pixel2
+{
+    auto ret = pixel2{};
+    auto& data = ret.data.emplace<static_solid>();
+    ret.colour = {
+        (200.0f + (rand() % 20) - 10) / 256.0f,
+        (200.0f + (rand() % 20) - 10) / 256.0f,
+        (200.0f + (rand() % 20) - 10) / 256.0f,
+        1.0
+    };
+    return ret;
+}
+
+
 }

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -8,7 +8,6 @@ pixel pixel::air()
 {
     return {
         .data = empty{},
-        .type = pixel_type::air,
         .colour = {
             44.0f / 256.0f,
             58.0f / 256.0f,
@@ -22,7 +21,6 @@ pixel pixel::sand()
 {
     return {
         .data = movable_solid{},
-        .type = pixel_type::sand,
         .colour = {
             (248.0f + (rand() % 20) - 10) / 256.0f,
             (239.0f + (rand() % 20) - 10) / 256.0f,
@@ -36,7 +34,6 @@ pixel pixel::rock()
 {
     return {
         .data = static_solid{},
-        .type = pixel_type::rock,
         .colour = {
             (200.0f + (rand() % 20) - 10) / 256.0f,
             (200.0f + (rand() % 20) - 10) / 256.0f,
@@ -50,7 +47,6 @@ pixel pixel::water()
 {
     return {
         .data = liquid{},
-        .type = pixel_type::water,
         .colour = {
             (27.0f  + (rand() % 20) - 10) / 256.0f,
             (156.0f + (rand() % 20) - 10) / 256.0f,
@@ -64,7 +60,6 @@ pixel pixel::red_sand()
 {
     return {
         .data = movable_solid{},
-        .type = pixel_type::sand,
         .colour = {
             (254.0f + (rand() % 20) - 10) / 256.0f,
             (164.0f + (rand() % 20) - 10) / 256.0f,

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -24,12 +24,14 @@ struct gas
 {
 };
 
+using empty = std::monostate;
+
 using pixel_data = std::variant<
     movable_solid,
     static_solid,
     liquid,
     gas,
-    std::monostate
+    empty
 >;
 
 struct pixel
@@ -37,6 +39,9 @@ struct pixel
     pixel_data data;
     glm::vec4  colour;
     bool       updated_this_frame = false;
+
+    template <typename... Ts>
+    auto is() const -> bool { return (std::holds_alternative<Ts>(data) || ...); }
 
     // TODO: Move out of struct
     static pixel air();

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <glm/glm.hpp>
 
+#include <variant>
+
 namespace sand {
 
 enum class pixel_type
@@ -28,5 +30,48 @@ struct pixel
     static pixel water();
     static pixel red_sand();
 };
+
+struct movable_solid
+{
+    glm::vec2 velocity = {0.0, 0.0};
+};
+
+struct static_solid
+{
+
+};
+
+struct liquid
+{
+    glm::vec2 velocity = {0.0, 0.0};
+};
+
+struct gas
+{
+
+};
+
+struct empty
+{
+};
+
+using pixel_data = std::variant<
+    movable_solid,
+    static_solid,
+    liquid,
+    gas,
+    empty
+>;
+
+struct pixel2
+{
+    pixel_data data;
+    glm::vec4  colour;
+    bool       updated_this_frame = false;
+};
+
+auto make_sand() -> pixel2;
+auto make_water() -> pixel2;
+auto make_stone() -> pixel2;
 
 }

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -16,7 +16,8 @@ struct static_solid
 
 struct liquid
 {
-    glm::vec2 velocity = {0.0, 0.0};
+    glm::vec2 velocity        = {0.0, 0.0};
+    int       dispersion_rate = 3;
 };
 
 struct gas

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -14,23 +14,6 @@ enum class pixel_type
     red_sand
 };
 
-struct pixel
-{
-    // Static Data
-    pixel_type type;
-    glm::vec4  colour;
-
-    // Dynamic Data
-    glm::vec2 velocity = {0.0, 0.0};
-    bool updated_this_frame = false;
-
-    static pixel air();
-    static pixel sand();
-    static pixel rock();
-    static pixel water();
-    static pixel red_sand();
-};
-
 struct movable_solid
 {
     glm::vec2 velocity = {0.0, 0.0};
@@ -63,15 +46,19 @@ using pixel_data = std::variant<
     empty
 >;
 
-struct pixel2
+struct pixel
 {
     pixel_data data;
+    pixel_type type;
     glm::vec4  colour;
     bool       updated_this_frame = false;
-};
 
-auto make_sand() -> pixel2;
-auto make_water() -> pixel2;
-auto make_stone() -> pixel2;
+    // TODO: Move out of struct
+    static pixel air();
+    static pixel sand();
+    static pixel rock();
+    static pixel water();
+    static pixel red_sand();
+};
 
 }

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -5,15 +5,6 @@
 
 namespace sand {
 
-enum class pixel_type
-{
-    air,
-    sand,
-    rock,
-    water,
-    red_sand
-};
-
 struct movable_solid
 {
     glm::vec2 velocity = {0.0, 0.0};
@@ -21,7 +12,6 @@ struct movable_solid
 
 struct static_solid
 {
-
 };
 
 struct liquid
@@ -31,7 +21,6 @@ struct liquid
 
 struct gas
 {
-
 };
 
 struct empty
@@ -49,7 +38,6 @@ using pixel_data = std::variant<
 struct pixel
 {
     pixel_data data;
-    pixel_type type;
     glm::vec4  colour;
     bool       updated_this_frame = false;
 

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -23,16 +23,12 @@ struct gas
 {
 };
 
-struct empty
-{
-};
-
 using pixel_data = std::variant<
     movable_solid,
     static_solid,
     liquid,
     gas,
-    empty
+    std::monostate
 >;
 
 struct pixel

--- a/src/random.hpp
+++ b/src/random.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include <random>
+
+namespace sand {
+
+inline auto random_from_range(float min, float max) -> float
+{
+    static std::default_random_engine gen;
+    return std::uniform_real_distribution(min, max)(gen);
+}
+
+inline auto random_from_range(int min, int max) -> int
+{
+    static std::default_random_engine gen;
+    return std::uniform_int_distribution(min, max)(gen);
+}
+
+inline auto coin_flip() -> bool
+{
+    return random_from_range(0, 1) == 0;
+}
+
+inline auto sign_flip() -> int
+{
+    return coin_flip() ? 1 : -1;
+}
+
+}

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -2,6 +2,7 @@
 #include "tile.h"
 #include "pixel.h"
 #include "world_settings.h"
+#include "timer.hpp"
 
 #include "graphics/window.h"
 #include "graphics/shader.h"
@@ -146,11 +147,10 @@ int main()
     double frame_length = 1.0 / 60.0;
     double accumulator = 0;
 
+    auto timer = sand::timer{};
+
     while (window.is_running()) {
-        prev = now;
-        now = clock.now();
-        std::chrono::duration<double> dt_duration = (now - prev);
-        double dt = dt_duration.count();
+        double dt = timer.on_update();
 
         accumulator += dt;
         bool updated = false;
@@ -160,12 +160,12 @@ int main()
             updated = true;
         }
 
-        if (updated) {
+        //if (updated) {
             window.clear();
             texture.set_data(tile->data());
             glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
             window.swap_buffers();
-        }
+        //}
         
         if (left_mouse_down) {
             auto coord = glm::floor(((float)sand::tile_size / (float)size) * window.get_mouse_pos());
@@ -178,6 +178,6 @@ int main()
         window.poll_events();
         
         auto mouse = window.get_mouse_pos();
-        window.set_name(fmt::format("Alchimia - Current tool: {}", loop.get_pixel_name()));
+        window.set_name(fmt::format("Alchimia - Current tool: {} [FPS: {}]", loop.get_pixel_name(), timer.frame_rate()));
     }
 }

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -139,14 +139,8 @@ int main()
     glBindVertexArray(VAO);
     glBindBuffer(GL_ARRAY_BUFFER, VBO);
 
-    std::chrono::steady_clock clock;
-    auto prev = clock.now();
-    auto now = clock.now();
-    double dt = 0;
-
-    double frame_length = 1.0 / 60.0;
-    double accumulator = 0;
-
+    auto frame_length = 1.0 / 60.0;
+    auto accumulator = 0.0;
     auto timer = sand::timer{};
 
     while (window.is_running()) {
@@ -168,7 +162,7 @@ int main()
         }
         
         if (left_mouse_down) {
-            auto coord = circle_offset(10.0f) + glm::ivec2(((float)sand::tile_size / (float)size) * window.get_mouse_pos());
+            auto coord = circle_offset(10.0f) + glm::ivec2((sand::tile_size_f / size) * window.get_mouse_pos());
             if (tile->valid(coord)) {
                 tile->set(coord, loop.get_pixel());
             }

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -3,6 +3,7 @@
 #include "pixel.h"
 #include "world_settings.h"
 #include "timer.hpp"
+#include "random.hpp"
 
 #include "graphics/window.h"
 #include "graphics/shader.h"

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -153,12 +153,19 @@ int main()
         double dt = dt_duration.count();
 
         accumulator += dt;
+        bool updated = false;
         while (accumulator > frame_length) {
             tile->simulate(settings, frame_length);
             accumulator -= frame_length;
+            updated = true;
         }
 
-        window.clear();
+        if (updated) {
+            window.clear();
+            texture.set_data(tile->data());
+            glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
+            window.swap_buffers();
+        }
         
         if (left_mouse_down) {
             auto coord = glm::floor(((float)sand::tile_size / (float)size) * window.get_mouse_pos());
@@ -168,9 +175,7 @@ int main()
             }
         }
 
-        texture.set_data(tile->data());
-        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
-        window.swap_and_poll();
+        window.poll_events();
         
         auto mouse = window.get_mouse_pos();
         window.set_name(fmt::format("Alchimia - Current tool: {}", loop.get_pixel_name()));

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -28,10 +28,6 @@ struct pixel_type_loop
 {
     int type = 0;
 
-public:
-    inline void operator++() { type = (type + 1) % 5; }
-    inline void operator--() { type = (type - 1) % 5; }
-
     auto get_pixel() -> sand::pixel
     {
         switch (type) {
@@ -123,9 +119,9 @@ int main()
         }
         else if (auto e = event.get_if<sand::mouse_scrolled_event>()) {
             if (e->y_offset > 0) {
-                ++loop;
+                ++loop.type;
             } else if (e->y_offset < 0) {
-                --loop;
+                --loop.type;
             }
         }
     });

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <array>
+#include <utility>
 #include <memory>
 #include <chrono>
 #include <random>

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -24,42 +24,35 @@
 
 constexpr glm::vec4 BACKGROUND = { 44.0f / 256.0f, 58.0f / 256.0f, 71.0f / 256.0f, 1.0 };
 
-std::string_view to_string(sand::pixel_type type)
+struct pixel_type_loop
 {
-    switch (type) {
-        case sand::pixel_type::air: return "air";
-        case sand::pixel_type::sand: return "sand";
-        case sand::pixel_type::water: return "water";
-        case sand::pixel_type::rock: return "rock";
-        case sand::pixel_type::red_sand: return "red_sand";
-        default: return "unknown";
-    }
-}
-
-class pixel_type_loop
-{
-    sand::pixel_type d_type = sand::pixel_type::air;
+    int type = 0;
 
 public:
-    sand::pixel_type get() const { return d_type; }
-    
-    inline void operator++() {
-        switch (d_type) {
-            case sand::pixel_type::air: d_type = sand::pixel_type::sand; return;
-            case sand::pixel_type::sand: d_type = sand::pixel_type::water; return;
-            case sand::pixel_type::water: d_type = sand::pixel_type::rock; return;
-            case sand::pixel_type::rock: d_type = sand::pixel_type::red_sand; return;
-            case sand::pixel_type::red_sand: d_type = sand::pixel_type::air; return;
+    inline void operator++() { type = (type + 1) % 5; }
+    inline void operator--() { type = (type - 1) % 5; }
+
+    auto get_pixel() -> sand::pixel
+    {
+        switch (type) {
+            case 0: return sand::pixel::air();
+            case 1: return sand::pixel::sand();
+            case 2: return sand::pixel::water();
+            case 3: return sand::pixel::rock();
+            case 4: return sand::pixel::red_sand();
+            default: return sand::pixel::air();
         }
     }
 
-    inline void operator--() {
-        switch (d_type) {
-            case sand::pixel_type::air: d_type = sand::pixel_type::red_sand; return;
-            case sand::pixel_type::sand: d_type = sand::pixel_type::air; return;
-            case sand::pixel_type::water: d_type = sand::pixel_type::sand; return;
-            case sand::pixel_type::rock: d_type = sand::pixel_type::water; return;
-            case sand::pixel_type::red_sand: d_type = sand::pixel_type::rock; return;
+    auto get_pixel_name() -> std::string_view
+    {
+        switch (type) {
+            case 0: return "air";
+            case 1: return "sand";
+            case 2: return "water";
+            case 3: return "rock";
+            case 4: return "red_sand";
+            default: return "unknown";
         }
     }
 };
@@ -114,8 +107,6 @@ int main()
     auto tile = std::make_unique<sand::tile>();
 
     pixel_type_loop loop;
-
-    auto current_tool = pixel_type::sand;
 
     bool left_mouse_down = false; // TODO: Remove, do it in a better way
 
@@ -177,13 +168,7 @@ int main()
             auto coord = glm::floor(((float)sand::tile_size / (float)size) * window.get_mouse_pos());
             coord += circle_offset(7.0f);
             if (tile->valid(coord)) {
-                switch (loop.get()) {
-                    case sand::pixel_type::air: tile->set(coord, pixel::air()); break;
-                    case sand::pixel_type::sand: tile->set(coord, pixel::sand()); break;
-                    case sand::pixel_type::water: tile->set(coord, pixel::water()); break;
-                    case sand::pixel_type::rock: tile->set(coord, pixel::rock()); break;
-                    case sand::pixel_type::red_sand: tile->set(coord, pixel::red_sand()); break;
-                }
+                tile->set(coord, loop.get_pixel());
             }
         }
 
@@ -192,6 +177,6 @@ int main()
         window.swap_and_poll();
         
         auto mouse = window.get_mouse_pos();
-        window.set_name(fmt::format("Alchimia - Current tool: {}", to_string(loop.get())));
+        window.set_name(fmt::format("Alchimia - Current tool: {}", loop.get_pixel_name()));
     }
 }

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -150,7 +150,7 @@ int main()
     auto timer = sand::timer{};
 
     while (window.is_running()) {
-        double dt = timer.on_update();
+        const double dt = timer.on_update();
 
         accumulator += dt;
         bool updated = false;
@@ -160,24 +160,21 @@ int main()
             updated = true;
         }
 
-        //if (updated) {
+        if (updated) {
             window.clear();
             texture.set_data(tile->data());
             glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
             window.swap_buffers();
-        //}
+        }
         
         if (left_mouse_down) {
-            auto coord = glm::floor(((float)sand::tile_size / (float)size) * window.get_mouse_pos());
-            coord += circle_offset(7.0f);
+            auto coord = circle_offset(10.0f) + glm::ivec2(((float)sand::tile_size / (float)size) * window.get_mouse_pos());
             if (tile->valid(coord)) {
                 tile->set(coord, loop.get_pixel());
             }
         }
 
         window.poll_events();
-        
-        auto mouse = window.get_mouse_pos();
         window.set_name(fmt::format("Alchimia - Current tool: {} [FPS: {}]", loop.get_pixel_name(), timer.frame_rate()));
     }
 }

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -90,4 +90,10 @@ pixel& tile::at(glm::ivec2 pos)
     return d_pixels[get_pos(pos)];
 }
 
+auto tile::swap(glm::ivec2 lhs, glm::ivec2 rhs) -> glm::ivec2
+{
+    std::swap(at(lhs), at(rhs));
+    return rhs;
+}
+
 }

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -34,17 +34,16 @@ void tile::simulate(const world_settings& settings, double dt)
     const auto inner = [&] (std::uint32_t x, std::uint32_t y) {
         auto& pixel = d_pixels[get_pos({x, y})];
         if (pixel.updated_this_frame) { return; }
-        switch (pixel.type) {
-            case pixel_type::sand: {
-                update_sand(d_pixels, {x, y}, settings, dt);
-            } break;
-            case pixel_type::rock: {
-                update_rock(d_pixels, {x, y}, settings, dt);
-            } break;
-            case pixel_type::water: {
-                update_water(d_pixels, {x, y}, settings, dt);
-            }
-            case pixel_type::air: return;
+
+        // TODO: Use std::visit
+        if (std::holds_alternative<movable_solid>(pixel.data)) {
+            update_sand(d_pixels, {x, y}, settings, dt);
+        }
+        else if (std::holds_alternative<static_solid>(pixel.data)) {
+            update_rock(d_pixels, {x, y}, settings, dt);
+        }
+        else if (std::holds_alternative<liquid>(pixel.data)) {
+            update_water(d_pixels, {x, y}, settings, dt);
         }
     };
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -37,13 +37,13 @@ void tile::simulate(const world_settings& settings, double dt)
 
         // TODO: Use std::visit
         if (std::holds_alternative<movable_solid>(pixel.data)) {
-            update_sand(d_pixels, {x, y}, settings, dt);
+            update_sand(*this, {x, y}, settings, dt);
         }
         else if (std::holds_alternative<static_solid>(pixel.data)) {
-            update_rock(d_pixels, {x, y}, settings, dt);
+            update_rock(*this, {x, y}, settings, dt);
         }
         else if (std::holds_alternative<liquid>(pixel.data)) {
-            update_water(d_pixels, {x, y}, settings, dt);
+            update_water(*this, {x, y}, settings, dt);
         }
     };
 
@@ -78,6 +78,16 @@ void tile::set(glm::ivec2 pos, const pixel& pixel)
 void tile::fill(const pixel& p)
 {
     d_pixels.fill(p);
+}
+
+const pixel& tile::at(glm::ivec2 pos) const
+{
+    return d_pixels[get_pos(pos)];
+}
+
+pixel& tile::at(glm::ivec2 pos)
+{
+    return d_pixels[get_pos(pos)];
 }
 
 }

--- a/src/tile.h
+++ b/src/tile.h
@@ -37,6 +37,9 @@ public:
     const pixel& at(glm::ivec2 pos) const;
     pixel& at(glm::ivec2 pos);
 
+    // Returns the rhs
+    auto swap(glm::ivec2 lhs, glm::ivec2 rhs) -> glm::ivec2;
+
     const buffer& data() const { return d_buffer; }
 };
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -35,6 +35,7 @@ public:
     void fill(const pixel& p);
 
     const pixel& at(glm::ivec2 pos) const;
+    pixel& at(glm::ivec2 pos);
 
     const buffer& data() const { return d_buffer; }
 };

--- a/src/tile.h
+++ b/src/tile.h
@@ -10,6 +10,7 @@
 namespace sand {
 
 static constexpr std::uint32_t tile_size = 256;
+static constexpr float         tile_size_d = static_cast<double>(tile_size);
 
 class tile
 {

--- a/src/tile.h
+++ b/src/tile.h
@@ -10,7 +10,7 @@
 namespace sand {
 
 static constexpr std::uint32_t tile_size = 256;
-static constexpr float         tile_size_d = static_cast<double>(tile_size);
+static constexpr float         tile_size_f = static_cast<double>(tile_size);
 
 class tile
 {

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -1,0 +1,29 @@
+#include "timer.hpp"
+
+namespace sand {
+
+timer::timer()
+    : d_clock()
+    , d_prev_time(d_clock.now())
+    , d_curr_time(d_prev_time)
+    , d_last_time_printed(d_prev_time)
+    , d_frame_count(0)
+{}
+
+double timer::on_update()
+{
+    d_prev_time = d_curr_time;
+    d_curr_time = d_clock.now();
+    ++d_frame_count;
+
+    if (d_curr_time - d_last_time_printed >= std::chrono::seconds(1)) {
+        d_frame_rate = d_frame_count;
+        d_frame_count = 0;
+        d_last_time_printed = d_curr_time;
+    }
+
+    std::chrono::duration<double> dt = d_curr_time - d_prev_time;
+    return dt.count();
+}
+
+}

--- a/src/timer.hpp
+++ b/src/timer.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <chrono>
+#include <cstddef>
+
+namespace sand {
+
+class timer
+{
+    using clock = std::chrono::steady_clock;
+
+    clock d_clock;
+    clock::time_point d_prev_time;
+    clock::time_point d_curr_time;
+    clock::time_point d_last_time_printed;
+    
+    std::uint32_t d_frame_count;
+    std::uint32_t d_frame_rate = 0;
+
+public:
+    timer();
+    double on_update();
+    std::uint32_t frame_rate() const { return d_frame_rate; }
+};
+
+}

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -43,29 +43,27 @@ auto can_pixel_move_to(const tile& pixels, glm::ivec2 src, glm::ivec2 dst) -> bo
 
 auto move_towards(tile& pixels, glm::ivec2 from, glm::ivec2 offset) -> glm::ivec2
 {
-    glm::ivec2 position = from;
+    glm::ivec2 curr_pos = from;
 
-    auto a = from;
-    auto b = from + offset;
-    int steps = glm::max(glm::abs(a.x - b.x), glm::abs(a.y - b.y));
+    const auto a = from;
+    const auto b = from + offset;
+    const auto steps = glm::max(glm::abs(a.x - b.x), glm::abs(a.y - b.y));
 
     for (int i = 0; i != steps; ++i) {
-        int x = a.x + (float)(i + 1)/steps * (b.x - a.x);
-        int y = a.y + (float)(i + 1)/steps * (b.y - a.y);
-        glm::ivec2 p{x, y};
-        if (!tile::valid(p)) { break; }
+        glm::ivec2 next_pos = a + (b - a) * (i + 1)/steps;
 
-        if (can_pixel_move_to(pixels, position, p)) {
-            std::swap(pixels.at(position), pixels.at(p));
-            position = p;
-        } else {
+        if (!can_pixel_move_to(pixels, curr_pos, next_pos)) {
             break;
         }
+        
+        curr_pos = pixels.swap(curr_pos, next_pos);
     }
-    if (position != from) {
-        pixels.at(position).updated_this_frame = true;
+
+    if (curr_pos != from) {
+        pixels.at(curr_pos).updated_this_frame = true;
     }
-    return position;
+
+    return curr_pos;
 }
 
 }

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -58,7 +58,8 @@ auto move_towards(tile::pixels& pixels, glm::ivec2 from, glm::ivec2 offset) -> b
 
 void update_sand(tile::pixels& pixels, glm::ivec2 pos, const world_settings& settings, double dt)
 {
-    auto& vel = pixels[get_pos(pos)].velocity;
+    auto& data = std::get<movable_solid>(pixels[get_pos(pos)].data);
+    auto& vel = data.velocity;
     vel += settings.gravity * (float)dt;
     glm::ivec2 offset{0, glm::max(1, (int)vel.y)};
 
@@ -78,14 +79,15 @@ void update_sand(tile::pixels& pixels, glm::ivec2 pos, const world_settings& set
         if (move_towards(pixels, pos, offset)) {
             return;
         } else {
-            pixels[get_pos(pos)].velocity = {0.0, 0.0};
+            data.velocity = {0.0, 0.0};
         }
     }
 }
 
 void update_water(tile::pixels& pixels, glm::ivec2 pos, const world_settings& settings, double dt)
 {
-    auto& vel = pixels[get_pos(pos)].velocity;
+    auto& data = std::get<liquid>(pixels[get_pos(pos)].data);
+    auto& vel = data.velocity;
     vel += settings.gravity * (float)dt;
     auto offset = glm::ivec2{0, glm::max(1, (int)vel.y)};
     
@@ -105,7 +107,7 @@ void update_water(tile::pixels& pixels, glm::ivec2 pos, const world_settings& se
     for (auto offset : offsets) {
         if (move_towards(pixels, pos, offset)) {
             if (offset.y == 0) {
-                pixels[get_pos(pos + offset)].velocity = {0.0, 0.0};
+                std::get<liquid>(pixels[get_pos(pos + offset)].data).velocity = {0.0, 0.0};
             }
             return;
         }

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -67,8 +67,9 @@ void update_sand(tile::pixels& pixels, glm::ivec2 pos, const world_settings& set
         return;
     }
 
-    std::array<glm::ivec2, 2> offsets = {
-        glm::ivec2{-1, 1}, glm::ivec2{1, 1},
+    auto offsets = std::array{
+        glm::ivec2{-1, 1},
+        glm::ivec2{1, 1},
     };
 
     if (rand() % 2) {
@@ -95,8 +96,11 @@ void update_water(tile::pixels& pixels, glm::ivec2 pos, const world_settings& se
         return;
     }
 
-    std::array<glm::ivec2, 4> offsets = {
-        glm::ivec2{-1, 1}, glm::ivec2{1, 1}, glm::ivec2{-1, 0}, glm::ivec2{1, 0}
+    auto offsets = std::array{
+        glm::ivec2{-1, 1},
+        glm::ivec2{1, 1},
+        glm::ivec2{-1, 0},
+        glm::ivec2{1, 0}
     };
 
     if (rand() % 2) {

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -16,10 +16,10 @@ std::size_t get_pos(glm::vec2 pos)
 auto move_towards(tile::pixels& pixels, glm::ivec2 from, glm::ivec2 offset) -> bool
 {
     const auto can_displace = [](const pixel& src, const pixel& dst) {
-        if (src.type == pixel_type::sand && (dst.type == pixel_type::air || dst.type == pixel_type::water)) {
+        if (std::holds_alternative<movable_solid>(src.data) && (std::holds_alternative<empty>(dst.data) || std::holds_alternative<liquid>(dst.data))) {
             return true;
         }
-        else if (src.type == pixel_type::water && dst.type == pixel_type::air) {
+        else if (std::holds_alternative<liquid>(src.data) && std::holds_alternative<empty>(dst.data)) {
             return true;
         }
         return false;

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -105,10 +105,10 @@ void update_water(tile::pixels& pixels, glm::ivec2 pos, const world_settings& se
     }
 
     for (auto offset : offsets) {
+        if (offset.y == 0) {
+            data.velocity = {0.0, 0.0};
+        }
         if (move_towards(pixels, pos, offset)) {
-            if (offset.y == 0) {
-                std::get<liquid>(pixels[get_pos(pos + offset)].data).velocity = {0.0, 0.0};
-            }
             return;
         }
     }

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -1,7 +1,9 @@
 #include "update_functions.h"
+#include "overloaded.hpp"
 
 #include <array>
 #include <utility>
+#include <variant>
 
 #include <glm/glm.hpp>
 
@@ -16,10 +18,10 @@ std::size_t get_pos(glm::vec2 pos)
 auto move_towards(tile::pixels& pixels, glm::ivec2 from, glm::ivec2 offset) -> bool
 {
     const auto can_displace = [](const pixel& src, const pixel& dst) {
-        if (std::holds_alternative<movable_solid>(src.data) && (std::holds_alternative<std::monostate>(dst.data) || std::holds_alternative<liquid>(dst.data))) {
+        if (src.is<movable_solid>() && dst.is<empty, liquid>()) {
             return true;
         }
-        else if (std::holds_alternative<liquid>(src.data) && std::holds_alternative<std::monostate>(dst.data)) {
+        else if (src.is<liquid>() && dst.is<empty>()) {
             return true;
         }
         return false;
@@ -70,7 +72,7 @@ auto move_towards_new(tile::pixels& pixels, glm::ivec2 from, glm::ivec2 offset) 
 
         auto curr_pos = get_pos(new_position);
         auto next_pos = get_pos(p);
-        if (std::holds_alternative<std::monostate>(pixels[next_pos].data)) {
+        if (pixels[next_pos].is<empty>()) {
             std::swap(pixels[curr_pos], pixels[next_pos]);
             curr_pos = next_pos;
             new_position = p;

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -55,37 +55,6 @@ auto move_towards(tile::pixels& pixels, glm::ivec2 from, glm::ivec2 offset) -> b
     return position != from;
 }
 
-// Only moves through air
-auto move_towards_new(tile::pixels& pixels, glm::ivec2 from, glm::ivec2 offset) -> bool
-{
-    auto new_position = from;
-
-    const auto src = from;
-    const auto dst = from + offset;
-    int steps = glm::max(glm::abs(src.x - dst.x), glm::abs(src.y - dst.y));
-
-    for (int i = 0; i != steps; ++i) {
-        int x = src.x + (float)(i + 1)/steps * (dst.x - src.x);
-        int y = src.y + (float)(i + 1)/steps * (dst.y - src.y);
-        glm::ivec2 p{x, y};
-        if (!tile::valid(p)) { break; }
-
-        auto curr_pos = get_pos(new_position);
-        auto next_pos = get_pos(p);
-        if (pixels[next_pos].is<empty>()) {
-            std::swap(pixels[curr_pos], pixels[next_pos]);
-            curr_pos = next_pos;
-            new_position = p;
-        } else {
-            break;
-        }
-    }
-    if (new_position != from) {
-        pixels[get_pos(new_position)].updated_this_frame = true;
-    }
-    return new_position != from;
-}
-
 }
 
 
@@ -125,7 +94,7 @@ void update_water(tile::pixels& pixels, glm::ivec2 pos, const world_settings& se
     vel += settings.gravity * (float)dt;
     auto offset = glm::ivec2{0, glm::max(1, (int)vel.y)};
     
-    if (move_towards_new(pixels, pos, offset)) {
+    if (move_towards(pixels, pos, offset)) {
         return;
     }
 
@@ -145,7 +114,7 @@ void update_water(tile::pixels& pixels, glm::ivec2 pos, const world_settings& se
         if (offset.y == 0) {
             data.velocity = {0.0, 0.0};
         }
-        if (move_towards_new(pixels, pos, offset)) {
+        if (move_towards(pixels, pos, offset)) {
             return;
         }
     }

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -123,15 +123,15 @@ void update_water(tile::pixels& pixels, glm::ivec2 pos, const world_settings& se
     vel += settings.gravity * (float)dt;
     auto offset = glm::ivec2{0, glm::max(1, (int)vel.y)};
     
-    if (move_towards(pixels, pos, offset)) {
+    if (move_towards_new(pixels, pos, offset)) {
         return;
     }
 
     auto offsets = std::array{
         glm::ivec2{-1, 1},
         glm::ivec2{1, 1},
-        glm::ivec2{-1, 0},
-        glm::ivec2{1, 0}
+        glm::ivec2{-1 * data.dispersion_rate, 0},
+        glm::ivec2{data.dispersion_rate, 0}
     };
 
     if (rand() % 2) {
@@ -143,7 +143,7 @@ void update_water(tile::pixels& pixels, glm::ivec2 pos, const world_settings& se
         if (offset.y == 0) {
             data.velocity = {0.0, 0.0};
         }
-        if (move_towards(pixels, pos, offset)) {
+        if (move_towards_new(pixels, pos, offset)) {
             return;
         }
     }

--- a/src/update_functions.h
+++ b/src/update_functions.h
@@ -6,8 +6,8 @@
 
 namespace sand {
 
-void update_sand(tile::pixels& pixels, glm::ivec2 pos, const world_settings& settings, double dt);
-void update_water(tile::pixels& pixels, glm::ivec2 pos, const world_settings& settings, double dt);
-void update_rock(tile::pixels& pixels, glm::ivec2 pos, const world_settings& settings, double dt);
+void update_sand(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt);
+void update_water(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt);
+void update_rock(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt);
     
 }


### PR DESCRIPTION
* Switch to a `variant`, remove the enum describing the pixel type.
* Added `random`, `overloaded` and `timer` modules from Sprocket.
* Optimise the renderer to only rerender the screen if a simulation step occurs.