### PR TITLE
Intertial Resistance

### DIFF
--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -40,7 +40,7 @@ pixel pixel::coal()
         .data = movable_solid{
             .velocity = {0.0, 0.0},
             .is_falling = true,
-            .intertial_resistance = 0.9f
+            .intertial_resistance = 0.95f
         },
         .colour = {
             (30.0f + (rand() % 20) - 10) / 256.0f,

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -23,7 +23,7 @@ pixel pixel::sand()
         .data = movable_solid{
             .velocity = {0.0, 0.0},
             .is_falling = true,
-            .intertial_resistance = 0.1f
+            .inertial_resistance = 0.1f
         },
         .colour = {
             (248.0f + (rand() % 20) - 10) / 256.0f,
@@ -40,7 +40,7 @@ pixel pixel::coal()
         .data = movable_solid{
             .velocity = {0.0, 0.0},
             .is_falling = true,
-            .intertial_resistance = 0.95f
+            .inertial_resistance = 0.95f
         },
         .colour = {
             (30.0f + (rand() % 20) - 10) / 256.0f,
@@ -83,7 +83,7 @@ pixel pixel::red_sand()
         .data = movable_solid{
             .velocity = {0.0, 0.0},
             .is_falling = true,
-            .intertial_resistance = 0.1f
+            .inertial_resistance = 0.1f
         },
         .colour = {
             (254.0f + (rand() % 20) - 10) / 256.0f,

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -20,11 +20,32 @@ pixel pixel::air()
 pixel pixel::sand()
 {
     return {
-        .data = movable_solid{},
+        .data = movable_solid{
+            .velocity = {0.0, 0.0},
+            .is_falling = true,
+            .intertial_resistance = 0.1f
+        },
         .colour = {
             (248.0f + (rand() % 20) - 10) / 256.0f,
             (239.0f + (rand() % 20) - 10) / 256.0f,
             (186.0f + (rand() % 20) - 10) / 256.0f,
+            1.0
+        }
+    };
+}
+
+pixel pixel::coal()
+{
+    return {
+        .data = movable_solid{
+            .velocity = {0.0, 0.0},
+            .is_falling = true,
+            .intertial_resistance = 0.9f
+        },
+        .colour = {
+            (30.0f + (rand() % 20) - 10) / 256.0f,
+            (39.0f + (rand() % 20) - 10) / 256.0f,
+            (46.0f + (rand() % 20) - 10) / 256.0f,
             1.0
         }
     };
@@ -59,7 +80,11 @@ pixel pixel::water()
 pixel pixel::red_sand()
 {
     return {
-        .data = movable_solid{},
+        .data = movable_solid{
+            .velocity = {0.0, 0.0},
+            .is_falling = true,
+            .intertial_resistance = 0.1f
+        },
         .colour = {
             (254.0f + (rand() % 20) - 10) / 256.0f,
             (164.0f + (rand() % 20) - 10) / 256.0f,

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -7,8 +7,11 @@ namespace sand {
 
 struct movable_solid
 {
+    // Runtime values
     glm::vec2 velocity;
     bool      is_falling;
+
+    // Static values - these define how the element behaves and should stay const
     float     intertial_resistance;
 };
 
@@ -18,7 +21,10 @@ struct static_solid
 
 struct liquid
 {
+    // Runtime values
     glm::vec2 velocity        = {0.0, 0.0};
+
+    // Static values - these define how the element behaves and should stay const
     int       dispersion_rate = 3;
 };
 

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -8,6 +8,8 @@ namespace sand {
 struct movable_solid
 {
     glm::vec2 velocity = {0.0, 0.0};
+    bool      is_falling = true;
+    float     intertial_resistance = 0.1f;
 };
 
 struct static_solid
@@ -42,6 +44,12 @@ struct pixel
 
     template <typename... Ts>
     auto is() const -> bool { return (std::holds_alternative<Ts>(data) || ...); }
+
+    template <typename T>
+    auto as() -> T& { return std::get<T>(data); }
+
+    template <typename T>
+    auto as() const -> const T& { return std::get<T>(data); }
 
     // TODO: Move out of struct
     static pixel air();

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -7,9 +7,9 @@ namespace sand {
 
 struct movable_solid
 {
-    glm::vec2 velocity = {0.0, 0.0};
-    bool      is_falling = true;
-    float     intertial_resistance = 0.1f;
+    glm::vec2 velocity;
+    bool      is_falling;
+    float     intertial_resistance;
 };
 
 struct static_solid
@@ -54,6 +54,7 @@ struct pixel
     // TODO: Move out of struct
     static pixel air();
     static pixel sand();
+    static pixel coal();
     static pixel rock();
     static pixel water();
     static pixel red_sand();

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -12,7 +12,7 @@ struct movable_solid
     bool      is_falling;
 
     // Static values - these define how the element behaves and should stay const
-    float     intertial_resistance;
+    float     inertial_resistance;
 };
 
 struct static_solid

--- a/src/random.hpp
+++ b/src/random.hpp
@@ -17,7 +17,7 @@ inline auto random_from_range(int min, int max) -> int
 
 inline auto coin_flip() -> bool
 {
-    return random_from_range(0.0f, 1.0f) > 0.5;
+    return random_from_range(0, 1) == 0;
 }
 
 inline auto sign_flip() -> int

--- a/src/random.hpp
+++ b/src/random.hpp
@@ -17,7 +17,7 @@ inline auto random_from_range(int min, int max) -> int
 
 inline auto coin_flip() -> bool
 {
-    return random_from_range(0, 1) == 0;
+    return random_from_range(0.0f, 1.0f) > 0.5;
 }
 
 inline auto sign_flip() -> int

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -36,9 +36,10 @@ struct pixel_type_loop
         switch (type) {
             case 0: return sand::pixel::air();
             case 1: return sand::pixel::sand();
-            case 2: return sand::pixel::water();
-            case 3: return sand::pixel::rock();
-            case 4: return sand::pixel::red_sand();
+            case 2: return sand::pixel::coal();
+            case 3: return sand::pixel::water();
+            case 4: return sand::pixel::rock();
+            case 5: return sand::pixel::red_sand();
             default: return sand::pixel::air();
         }
     }
@@ -48,9 +49,10 @@ struct pixel_type_loop
         switch (type) {
             case 0: return "air";
             case 1: return "sand";
-            case 2: return "water";
-            case 3: return "rock";
-            case 4: return "red_sand";
+            case 2: return "coal";
+            case 3: return "water";
+            case 4: return "rock";
+            case 5: return "red_sand";
             default: return "unknown";
         }
     }

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -154,6 +154,7 @@ int main()
             tile->simulate(settings, frame_length);
             accumulator -= frame_length;
             updated = true;
+
         }
 
         if (updated) {
@@ -161,16 +162,15 @@ int main()
             texture.set_data(tile->data());
             glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
             window.swap_buffers();
+            window.poll_events();
+            window.set_name(fmt::format("Sandfall - Current tool: {} [FPS: {}]", loop.get_pixel_name(), timer.frame_rate()));
         }
         
         if (left_mouse_down) {
-            auto coord = circle_offset(10.0f) + glm::ivec2((sand::tile_size_f / size) * window.get_mouse_pos());
+            const auto coord = circle_offset(10.0f) + glm::ivec2((sand::tile_size_f / size) * window.get_mouse_pos());
             if (tile->valid(coord)) {
                 tile->set(coord, loop.get_pixel());
             }
         }
-
-        window.poll_events();
-        window.set_name(fmt::format("Alchimia - Current tool: {} [FPS: {}]", loop.get_pixel_name(), timer.frame_rate()));
     }
 }

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -39,12 +39,12 @@ auto set_adjacent_free_falling(tile& pixels, glm::ivec2 pos) -> void
 
     if (pixels.valid(l) && pixels.at(l).is<movable_solid>()) {
         auto& px = pixels.at(l).as<movable_solid>();
-        px.is_falling = random_from_range(0.0f, 1.0f) > px.intertial_resistance || px.is_falling;
+        px.is_falling = random_from_range(0.0f, 1.0f) > px.inertial_resistance || px.is_falling;
     }
 
     if (pixels.valid(r) && pixels.at(r).is<movable_solid>()) {
         auto& px = pixels.at(r).as<movable_solid>();
-        px.is_falling = random_from_range(0.0f, 1.0f) > px.intertial_resistance || px.is_falling;
+        px.is_falling = random_from_range(0.0f, 1.0f) > px.inertial_resistance || px.is_falling;
     }
 }
 

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -32,6 +32,22 @@ auto can_pixel_move_to(const tile& pixels, glm::ivec2 src, glm::ivec2 dst) -> bo
     return false;
 }
 
+auto set_adjacent_free_falling(tile& pixels, glm::ivec2 pos) -> void
+{
+    const auto l = pos + glm::ivec2{-1, 0};
+    const auto r = pos + glm::ivec2{1, 0};
+
+    if (pixels.valid(l) && pixels.at(l).is<movable_solid>()) {
+        auto& px = pixels.at(l).as<movable_solid>();
+        px.is_falling = random_from_range(0.0f, 1.0f) > px.intertial_resistance || px.is_falling;
+    }
+
+    if (pixels.valid(r) && pixels.at(r).is<movable_solid>()) {
+        auto& px = pixels.at(r).as<movable_solid>();
+        px.is_falling = random_from_range(0.0f, 1.0f) > px.intertial_resistance || px.is_falling;
+    }
+}
+
 auto move_towards(tile& pixels, glm::ivec2 from, glm::ivec2 offset) -> glm::ivec2
 {
     glm::ivec2 curr_pos = from;
@@ -41,13 +57,14 @@ auto move_towards(tile& pixels, glm::ivec2 from, glm::ivec2 offset) -> glm::ivec
     const auto steps = glm::max(glm::abs(a.x - b.x), glm::abs(a.y - b.y));
 
     for (int i = 0; i != steps; ++i) {
-        glm::ivec2 next_pos = a + (b - a) * (i + 1)/steps;
+        const auto next_pos = a + (b - a) * (i + 1)/steps;
 
         if (!can_pixel_move_to(pixels, curr_pos, next_pos)) {
             break;
         }
 
         curr_pos = pixels.swap(curr_pos, next_pos);
+        set_adjacent_free_falling(pixels, curr_pos);
     }
 
     if (curr_pos != from) {
@@ -62,6 +79,8 @@ auto move_towards(tile& pixels, glm::ivec2 from, glm::ivec2 offset) -> glm::ivec
 
 void update_sand(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt)
 {
+    const auto original_pos = pos;
+
     // Apply gravity if can move down
     if (can_pixel_move_to(pixels, pos, below(pos))) {
         auto& vel = std::get<movable_solid>(pixels.at(pos).data).velocity;
@@ -75,34 +94,35 @@ void update_sand(tile& pixels, glm::ivec2 pos, const world_settings& settings, d
     else {
         auto& vel = std::get<movable_solid>(pixels.at(pos).data).velocity;
         if (vel.y > 5.0 && vel.x == 0.0) {
-            vel.x = 0.2 * vel.y * sign_flip();
+            vel.x = random_from_range(0.2f, 0.4f) * vel.y * sign_flip();
             vel.y = 0.0;
         }
         vel.x *= 0.8;
 
-        pos = move_towards(pixels, pos, vel);
+        pos = move_towards(pixels, pos, {vel.x, 0});
         
     }
 
-    if (pixels.at(pos).updated_this_frame) {
-        return;
-    }
+    if (!pixels.at(pos).updated_this_frame && pixels.at(pos).as<movable_solid>().is_falling) {
+        auto offsets = std::array{
+            glm::ivec2{-1, 1},
+            glm::ivec2{1, 1},
+        };
 
-    auto offsets = std::array{
-        glm::ivec2{-1, 1},
-        glm::ivec2{1, 1},
-    };
+        if (rand() % 2) {
+            std::swap(offsets[0], offsets[1]);
+        }
 
-    if (rand() % 2) {
-        std::swap(offsets[0], offsets[1]);
-    }
-
-    auto& data = std::get<movable_solid>(pixels.at(pos).data);
-    for (auto offset : offsets) {
-        if (move_towards(pixels, pos, offset) != pos) {
-            return;
+        auto& data = std::get<movable_solid>(pixels.at(pos).data);
+        for (auto offset : offsets) {
+            pos = move_towards(pixels, pos, offset);
+            if (pos != original_pos) {
+                break;
+            }
         }
     }
+
+    pixels.at(pos).as<movable_solid>().is_falling = (pos != original_pos);
 }
 
 void update_water(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt)


### PR DESCRIPTION
* Added `is_falling` and `inertial_resistance` to `movable_solid`. When `is_falling` is false, the sim does not check diagonally to try and move.
* Moving on a frame sets `is_falling` to true. Additionally, when a movable solid pixel moves, it tries to set `is_falling` to true of its two adjacent pixels. The chance of this happening depends on the `inertial_resistance`.
* Added `coal` which is identical to `sand`, except that `coal` has an `inertial_resistance` of `0.95` while `sand` has a low resistance of `0.1`.