### PR TITLE
Trailing Return Type Everywhere

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "vendor/-f"]
-	path = vendor/-f
-	url = https://github.com/ocornut/imgui.git
 [submodule "vendor/imgui"]
 	path = vendor/imgui
 	url = https://github.com/ocornut/imgui.git

--- a/src/graphics/shader.cpp
+++ b/src/graphics/shader.cpp
@@ -11,7 +11,7 @@
 namespace sand {
 namespace {
 
-std::uint32_t compile_shader(std::uint32_t type, const std::string& source)
+auto compile_shader(std::uint32_t type, const std::string& source) -> std::uint32_t
 {
 	std::uint32_t id = glCreateShader(type);
 	const char* src = source.c_str();
@@ -32,7 +32,7 @@ std::uint32_t compile_shader(std::uint32_t type, const std::string& source)
 
 }
 
-std::string parse_shader(const std::string& filepath)
+auto parse_shader(const std::string& filepath) -> std::string
 {
 	if (!std::filesystem::exists(filepath)) {
 		log::fatal("Shader file '{}' does not exist!", filepath);
@@ -54,27 +54,27 @@ shader::shader(const std::string& vertex_shader, const std::string& fragment_sha
 	glValidateProgram(d_program);
 }
 
-std::uint32_t shader::get_location(const std::string& name) const
+auto shader::get_location(const std::string& name) const -> std::uint32_t
 {
     return glGetUniformLocation(d_program, name.c_str());
 }
 
-void shader::bind() const
+auto shader::bind() const -> void
 {
     glUseProgram(d_program);
 }
 
-void shader::unbind() const
+auto shader::unbind() const -> void
 {
     glUseProgram(0);
 }
 
-void shader::load_mat4(const std::string& name, const glm::mat4& matrix) const
+auto shader::load_mat4(const std::string& name, const glm::mat4& matrix) const -> void
 {
     glUniformMatrix4fv(get_location(name), 1, GL_FALSE, glm::value_ptr(matrix));
 }
 
-void shader::load_sampler(const std::string& name, int value) const
+auto shader::load_sampler(const std::string& name, int value) const -> void
 {
 	glProgramUniform1i(d_program, get_location(name), value);
 }

--- a/src/graphics/shader.h
+++ b/src/graphics/shader.h
@@ -19,11 +19,11 @@ class shader
 public:
     shader(const std::string& vertex_shader, const std::string& fragment_shader);
 
-    void bind() const;
-    void unbind() const;
+    auto bind() const -> void;
+    auto unbind() const -> void;
 
-    void load_mat4(const std::string& name, const glm::mat4& matrix) const;
-    void load_sampler(const std::string& name, int value) const;
+    auto load_mat4(const std::string& name, const glm::mat4& matrix) const -> void;
+    auto load_sampler(const std::string& name, int value) const -> void;
 };
 
 }

--- a/src/graphics/ui.cpp
+++ b/src/graphics/ui.cpp
@@ -22,14 +22,14 @@ ui::~ui()
     ImGui::DestroyContext();
 }
 
-void ui::begin_frame()
+auto ui::begin_frame() -> void
 {
     ImGui_ImplOpenGL3_NewFrame();
     ImGui_ImplGlfw_NewFrame();
     ImGui::NewFrame();
 }
 
-void ui::end_frame()
+auto ui::end_frame() -> void
 {
     ImGui::EndFrame();
     ImGui::Render();

--- a/src/graphics/ui.hpp
+++ b/src/graphics/ui.hpp
@@ -9,8 +9,8 @@ public:
     ui(sand::window& window);
     ~ui();
 
-    void begin_frame();
-    void end_frame();
+    auto begin_frame() -> void;
+    auto end_frame() -> void;
 };
 
 }

--- a/src/graphics/window.cpp
+++ b/src/graphics/window.cpp
@@ -220,4 +220,19 @@ void window::set_callback(const callback_t& callback)
     d_data.callback = callback;
 }
 
+auto window::width() const -> float
+{
+	return static_cast<float>(d_data.width); 
+}
+
+auto window::height() const -> float
+{
+	return static_cast<float>(d_data.height); 
+}
+
+auto window::native_handle() -> GLFWwindow*
+{
+	return d_data.native_window;
+}
+
 }

--- a/src/graphics/window.h
+++ b/src/graphics/window.h
@@ -34,32 +34,31 @@ class window
 {
     window_data d_data;
 
-public:
-    window(const std::string&, int width, int height);
-    ~window();
-
-    void clear() const;
-    void swap_buffers();
-    void poll_events();
-
-    bool is_running() const;
-
-    glm::vec2 get_mouse_pos() const;
-
-    void set_name(const std::string& name);
-    void set_callback(const callback_t& callback);
-
-    float width() const { return (float)d_data.width; }
-    float height() const { return (float)d_data.height; }
-
-    GLFWwindow* native_handle() { return d_data.native_window; }
-
-private:
     window(const window&) = delete;
     window& operator=(const window&) = delete;
 
     window(window&&) = delete;
     window& operator=(window&&) = delete;
+
+public:
+    window(const std::string&, int width, int height);
+    ~window();
+
+    auto clear() const -> void;
+    auto swap_buffers() -> void;
+    auto poll_events() -> void;
+
+    auto is_running() const -> bool;
+
+    auto get_mouse_pos() const -> glm::vec2;
+
+    auto set_name(const std::string& name) -> void;
+    auto set_callback(const callback_t& callback) -> void;
+
+    auto width() const -> float;
+    auto height() const -> float;
+
+    auto native_handle() -> GLFWwindow*;
 };
 
 }

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -7,7 +7,7 @@ namespace sand {
 auto pixel::air() -> pixel
 {
     return {
-        .data = std::monostate{},
+        .data = empty{},
         .colour = {
             44.0f / 256.0f,
             58.0f / 256.0f,
@@ -23,7 +23,8 @@ auto pixel::sand() -> pixel
         .data = movable_solid{
             .velocity = {0.0, 0.0},
             .is_falling = true,
-            .inertial_resistance = 0.1f
+            .inertial_resistance = 0.1f,
+            .horizontal_transfer = 0.3f
         },
         .colour = {
             (248.0f + (rand() % 20) - 10) / 256.0f,
@@ -40,7 +41,8 @@ auto pixel::coal() -> pixel
         .data = movable_solid{
             .velocity = {0.0, 0.0},
             .is_falling = true,
-            .inertial_resistance = 0.95f
+            .inertial_resistance = 0.95f,
+            .horizontal_transfer = 0.1f
         },
         .colour = {
             (30.0f + (rand() % 20) - 10) / 256.0f,
@@ -67,7 +69,10 @@ auto pixel::rock() -> pixel
 auto pixel::water() -> pixel
 {
     return {
-        .data = liquid{},
+        .data = liquid{
+            .velocity = {0.0, 0.0},
+            .dispersion_rate = 3
+        },
         .colour = {
             (27.0f  + (rand() % 20) - 10) / 256.0f,
             (156.0f + (rand() % 20) - 10) / 256.0f,
@@ -83,7 +88,8 @@ auto pixel::red_sand() -> pixel
         .data = movable_solid{
             .velocity = {0.0, 0.0},
             .is_falling = true,
-            .inertial_resistance = 0.1f
+            .inertial_resistance = 0.1f,
+            .horizontal_transfer = 0.3f
         },
         .colour = {
             (254.0f + (rand() % 20) - 10) / 256.0f,

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -4,7 +4,7 @@
 
 namespace sand {
 
-pixel pixel::air()
+auto pixel::air() -> pixel
 {
     return {
         .data = std::monostate{},
@@ -17,7 +17,7 @@ pixel pixel::air()
     };
 }
 
-pixel pixel::sand()
+auto pixel::sand() -> pixel
 {
     return {
         .data = movable_solid{
@@ -34,7 +34,7 @@ pixel pixel::sand()
     };
 }
 
-pixel pixel::coal()
+auto pixel::coal() -> pixel
 {
     return {
         .data = movable_solid{
@@ -51,7 +51,7 @@ pixel pixel::coal()
     };
 }
 
-pixel pixel::rock()
+auto pixel::rock() -> pixel
 {
     return {
         .data = static_solid{},
@@ -64,7 +64,7 @@ pixel pixel::rock()
     };
 }
 
-pixel pixel::water()
+auto pixel::water() -> pixel
 {
     return {
         .data = liquid{},
@@ -77,7 +77,7 @@ pixel pixel::water()
     };
 }
 
-pixel pixel::red_sand()
+auto pixel::red_sand() -> pixel
 {
     return {
         .data = movable_solid{

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -57,13 +57,12 @@ struct pixel
     template <typename T>
     auto as() const -> const T& { return std::get<T>(data); }
 
-    // TODO: Move out of struct
-    static pixel air();
-    static pixel sand();
-    static pixel coal();
-    static pixel rock();
-    static pixel water();
-    static pixel red_sand();
+    static auto air() -> pixel;
+    static auto sand() -> pixel;
+    static auto coal() -> pixel;
+    static auto rock() -> pixel;
+    static auto water() -> pixel;
+    static auto red_sand() -> pixel;
 };
 
 }

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -11,8 +11,9 @@ struct movable_solid
     glm::vec2 velocity;
     bool      is_falling;
 
-    // Static values - these define how the element behaves and should stay const
+    // Static values
     float     inertial_resistance;
+    float     horizontal_transfer;
 };
 
 struct static_solid
@@ -22,10 +23,10 @@ struct static_solid
 struct liquid
 {
     // Runtime values
-    glm::vec2 velocity        = {0.0, 0.0};
+    glm::vec2 velocity;
 
-    // Static values - these define how the element behaves and should stay const
-    int       dispersion_rate = 3;
+    // Static values
+    int       dispersion_rate;
 };
 
 struct gas

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -5,6 +5,7 @@
 #include "utility/timer.hpp"
 #include "utility/random.hpp"
 #include "utility/log.h"
+#include "utility/overloaded.hpp"
 
 #include "graphics/window.h"
 #include "graphics/shader.h"
@@ -52,7 +53,7 @@ auto circle_offset(float radius) -> glm::ivec2
     return { r * std::cos(theta), r * std::sin(theta) };
 }
 
-int main()
+auto main() -> int
 {
     using namespace sand;
 
@@ -94,23 +95,17 @@ int main()
     window.set_callback([&](sand::event& event) {
         auto& io = ImGui::GetIO();
         if (event.is_keyboard_event() && io.WantCaptureKeyboard) {
-            event.consume();
             return;
         }
         if (event.is_mount_event() && io.WantCaptureMouse) {
-            event.consume();
             return;
         }
 
-        if (auto e = event.get_if<sand::mouse_pressed_event>()) {
-            switch (e->button) {
-                case 0: left_mouse_down = true; return;
-            }
+        if (event.is<sand::mouse_pressed_event>()) {
+            if (event.as<sand::mouse_pressed_event>().button == 0) { left_mouse_down = true; }
         }
-        else if (auto e = event.get_if<sand::mouse_released_event>()) {
-            switch (e->button) {
-                case 0: left_mouse_down = false; return;
-            }
+        else if (event.is<sand::mouse_released_event>()) {
+            if (event.as<sand::mouse_released_event>().button == 0) { left_mouse_down = false; }
         }
     });
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -10,7 +10,7 @@
 namespace sand {
 namespace {
 
-std::size_t get_pos(glm::vec2 pos)
+auto get_pos(glm::vec2 pos) -> std::size_t
 {
     return pos.x + tile_size * pos.y;
 }
@@ -24,12 +24,12 @@ tile::tile()
     d_buffer.fill(default_pixel.colour);
 }
 
-bool tile::valid(glm::ivec2 pos)
+auto tile::valid(glm::ivec2 pos) -> bool
 {
     return 0 <= pos.x && pos.x < tile_size && 0 <= pos.y && pos.y < tile_size;
 }
 
-void tile::simulate(const world_settings& settings, double dt)
+auto tile::simulate(const world_settings& settings, double dt) -> void
 {
     const auto inner = [&] (std::uint32_t x, std::uint32_t y) {
         auto& pixel = d_pixels[get_pos({x, y})];
@@ -69,23 +69,23 @@ void tile::simulate(const world_settings& settings, double dt)
     }
 }
 
-void tile::set(glm::ivec2 pos, const pixel& pixel)
+auto tile::set(glm::ivec2 pos, const pixel& pixel) -> void
 {
     assert(valid(pos));
     d_pixels[get_pos(pos)] = pixel;
 }
 
-void tile::fill(const pixel& p)
+auto tile::fill(const pixel& p) -> void
 {
     d_pixels.fill(p);
 }
 
-const pixel& tile::at(glm::ivec2 pos) const
+auto tile::at(glm::ivec2 pos) const -> const pixel&
 {
     return d_pixels[get_pos(pos)];
 }
 
-pixel& tile::at(glm::ivec2 pos)
+auto tile::at(glm::ivec2 pos) -> pixel&
 {
     return d_pixels[get_pos(pos)];
 }

--- a/src/tile.h
+++ b/src/tile.h
@@ -15,7 +15,6 @@ static constexpr float         tile_size_f = static_cast<double>(tile_size);
 class tile
 {
 public:
-
     using buffer = std::array<glm::vec4, tile_size * tile_size>;
     using pixels = std::array<pixel, tile_size * tile_size>;
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -27,20 +27,20 @@ public:
     tile();
 
     // Returns true if the given position exists and false otherwise
-    static bool valid(glm::ivec2 pos);
+    static auto valid(glm::ivec2 pos) -> bool;
     
-    void simulate(const world_settings& settings, double dt);
+    auto simulate(const world_settings& settings, double dt) -> void;
 
-    void set(glm::ivec2 pos, const pixel& p);
-    void fill(const pixel& p);
+    auto set(glm::ivec2 pos, const pixel& p) -> void;
+    auto fill(const pixel& p) -> void;
 
-    const pixel& at(glm::ivec2 pos) const;
-    pixel& at(glm::ivec2 pos);
+    auto at(glm::ivec2 pos) const -> const pixel&;
+    auto at(glm::ivec2 pos) -> pixel&;
 
     // Returns the rhs
     auto swap(glm::ivec2 lhs, glm::ivec2 rhs) -> glm::ivec2;
 
-    const buffer& data() const { return d_buffer; }
+    auto data() const -> const buffer& { return d_buffer; }
 };
 
 }

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -79,7 +79,7 @@ auto move_towards(tile& pixels, glm::ivec2 from, glm::ivec2 offset) -> glm::ivec
 }
 
 
-void update_sand(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt)
+auto update_sand(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt) -> void
 {
     const auto original_pos = pos;
     const auto scope = scope_exit{[&] {
@@ -128,7 +128,7 @@ void update_sand(tile& pixels, glm::ivec2 pos, const world_settings& settings, d
     }
 }
 
-void update_water(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt)
+auto update_water(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt) -> void
 {
     auto& data = std::get<liquid>(pixels.at(pos).data);
     auto& vel = data.velocity;
@@ -161,7 +161,7 @@ void update_water(tile& pixels, glm::ivec2 pos, const world_settings& settings, 
     }
 }
 
-void update_rock(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt)
+auto update_rock(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt) -> void
 {
     pixels.at(pos).updated_this_frame = true;
 }

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -97,9 +97,11 @@ auto update_sand(tile& pixels, glm::ivec2 pos, const world_settings& settings, d
 
     // Transfer to horizontal
     else {
-        auto& vel = std::get<movable_solid>(pixels.at(pos).data).velocity;
+        auto& data = std::get<movable_solid>(pixels.at(pos).data);
+        auto& vel = data.velocity;
         if (vel.y > 5.0 && vel.x == 0.0) {
-            vel.x = random_from_range(0.2f, 0.4f) * vel.y * sign_flip();
+            const auto ht = data.horizontal_transfer;
+            vel.x = random_from_range(std::max(0.0f, ht - 0.1f), std::min(1.0f, ht + 0.1f)) * vel.y * sign_flip();
             vel.y = 0.0;
         }
         vel.x *= 0.8;

--- a/src/update_functions.h
+++ b/src/update_functions.h
@@ -6,8 +6,8 @@
 
 namespace sand {
 
-void update_sand(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt);
-void update_water(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt);
-void update_rock(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt);
+auto update_sand(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt) -> void;
+auto update_water(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt) -> void;
+auto update_rock(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt) -> void;
     
 }


### PR DESCRIPTION
* Use `auto function() -> return_type` style everywhere.
* Add `horizontal_transfer` attribute to `movable_solid`, coal transfers less than sand (may be removed when added a mass attribute).
* `event` is now based on `std::variant` instead of `std::any`. Removed the consume flag since it isnt needed.
* Added `event::is_window_event` for completeness.