### PR TITLE
Refactor Pixel and add Steam

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -4,7 +4,7 @@ Size=400,400
 Collapsed=0
 
 [Window][Dear ImGui Demo]
-Pos=792,691
+Pos=719,675
 Size=478,528
 Collapsed=1
 

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -2,6 +2,7 @@
 #include "utility.hpp"
 
 #include <cstdlib>
+#include <vector>
 
 namespace sand {
 namespace {
@@ -18,10 +19,53 @@ auto light_noise() -> glm::vec4
 
 }
 
+pixel_properties get_pixel_properties(pixel_type type)
+{
+    switch (type) {
+        case pixel_type::none:
+            return {};
+        case pixel_type::sand:
+            return {
+                .movement = pixel_movement::movable_solid,
+                .inertial_resistance = 0.1f,
+                .horizontal_transfer = 0.3f,
+            };
+        case pixel_type::dirt:
+            return {
+                .movement = pixel_movement::movable_solid,
+                .inertial_resistance = 0.4f,
+                .horizontal_transfer = 0.2f,
+            };
+        case pixel_type::coal:
+            return {
+                .movement = pixel_movement::movable_solid,
+                .inertial_resistance = 0.95f,
+                .horizontal_transfer = 0.1f,
+            };
+        case pixel_type::water:
+            return {
+                .movement = pixel_movement::liquid,
+                .dispersion_rate = 5
+            };
+        case pixel_type::lava:
+            return {
+                .movement = pixel_movement::liquid,
+                .dispersion_rate = 1
+            };
+        case pixel_type::rock:
+            return {
+                .movement = pixel_movement::immovable_solid
+            };
+        default:
+            print("ERROR: Unknown pixel type {}\n", static_cast<int>(type));
+            return {};
+    }
+}
+
 auto pixel::air() -> pixel
 {
     return {
-        .data = empty{},
+        .type = pixel_type::none,
         .colour = from_hex(0x2C3A47)
     };
 }
@@ -29,46 +73,34 @@ auto pixel::air() -> pixel
 auto pixel::sand() -> pixel
 {
     return {
-        .data = movable_solid{
-            .velocity = {0.0, 0.0},
-            .is_falling = true,
-            .inertial_resistance = 0.1f,
-            .horizontal_transfer = 0.3f
-        },
-        .colour = from_hex(0xF8EFBA) + light_noise()
+        .type = pixel_type::sand,
+        .colour = from_hex(0xF8EFBA) + light_noise(),
+        .is_falling = true,
     };
 }
 
 auto pixel::coal() -> pixel
 {
     return {
-        .data = movable_solid{
-            .velocity = {0.0, 0.0},
-            .is_falling = true,
-            .inertial_resistance = 0.95f,
-            .horizontal_transfer = 0.1f
-        },
-        .colour = from_hex(0x1E272E) + light_noise()
+        .type = pixel_type::coal,
+        .colour = from_hex(0x1E272E) + light_noise(),
+        .is_falling = true,
     };
 }
 
 auto pixel::dirt() -> pixel
 {
     return {
-        .data = movable_solid{
-            .velocity = {0.0, 0.0},
-            .is_falling = true,
-            .inertial_resistance = 0.4f,
-            .horizontal_transfer = 0.2f
-        },
-        .colour = from_hex(0x5C1D06) + light_noise()
+        .type = pixel_type::dirt,
+        .colour = from_hex(0x5C1D06) + light_noise(),
+        .is_falling = true,
     };
 }
 
 auto pixel::rock() -> pixel
 {
     return {
-        .data = static_solid{},
+        .type = pixel_type::rock,
         .colour = from_hex(0xC8C8C8) + light_noise()
     };
 }
@@ -76,22 +108,16 @@ auto pixel::rock() -> pixel
 auto pixel::water() -> pixel
 {
     return {
-        .data = liquid{
-            .velocity = {0.0, 0.0},
-            .dispersion_rate = 5
-        },
-        .colour = from_hex(0x1B9CFC) + light_noise()
+        .type = pixel_type::water,
+        .colour = from_hex(0x1B9CFC) + light_noise(),
     };
 }
 
 auto pixel::lava() -> pixel
 {
     return {
-        .data = liquid{
-            .velocity = {0.0, 0.0},
-            .dispersion_rate = 1
-        },
-        .colour = from_hex(0xF97F51) + light_noise()
+        .type = pixel_type::lava,
+        .colour = from_hex(0xF97F51) + light_noise(),
     };
 }
 

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -50,7 +50,12 @@ pixel_properties get_pixel_properties(pixel_type type)
         case pixel_type::lava:
             return {
                 .movement = pixel_movement::liquid,
-                .dispersion_rate = 1
+                .dispersion_rate = 1,
+                .affect_neighbour = [](pixel& me, pixel& them) {
+                    if (them.type == pixel_type::water) {
+                        them = pixel::steam();
+                    }
+                }
             };
         case pixel_type::rock:
             return {

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -56,6 +56,10 @@ pixel_properties get_pixel_properties(pixel_type type)
             return {
                 .movement = pixel_movement::immovable_solid
             };
+        case pixel_type::steam:
+            return {
+                .movement = pixel_movement::gas
+            };
         default:
             print("ERROR: Unknown pixel type {}\n", static_cast<int>(type));
             return {};
@@ -118,6 +122,14 @@ auto pixel::lava() -> pixel
     return {
         .type = pixel_type::lava,
         .colour = from_hex(0xF97F51) + light_noise(),
+    };
+}
+
+auto pixel::steam() -> pixel
+{
+    return {
+        .type = pixel_type::steam,
+        .colour = from_hex(0x9AECDB) + light_noise(),
     };
 }
 

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -63,7 +63,8 @@ pixel_properties get_pixel_properties(pixel_type type)
             };
         case pixel_type::steam:
             return {
-                .movement = pixel_movement::gas
+                .movement = pixel_movement::gas,
+                .dispersion_rate = 9
             };
         default:
             print("ERROR: Unknown pixel type {}\n", static_cast<int>(type));

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -1,62 +1,47 @@
 #pragma once
 #include <glm/glm.hpp>
-
-#include <variant>
+#include <cstdint>
 
 namespace sand {
 
-struct movable_solid
+enum class pixel_movement : std::uint8_t
 {
-    // Runtime values
-    glm::vec2 velocity;
-    bool      is_falling;
-
-    // Static values
-    float     inertial_resistance;
-    float     horizontal_transfer;
-};
-
-struct static_solid
-{
-};
-
-struct liquid
-{
-    // Runtime values
-    glm::vec2 velocity;
-
-    // Static values
-    int       dispersion_rate;
-};
-
-struct gas
-{
-};
-
-using empty = std::monostate;
-
-using pixel_data = std::variant<
+    none,
+    immovable_solid,
     movable_solid,
-    static_solid,
     liquid,
     gas,
-    empty
->;
+};
+
+enum class pixel_type : std::uint8_t
+{
+    none  = 0,
+    sand  = 1,
+    dirt  = 2,
+    coal  = 3,
+    water = 4,
+    lava  = 5,
+    rock  = 6,
+};
+
+struct pixel_properties
+{
+    pixel_movement movement            = pixel_movement::none;
+    float          inertial_resistance = 0.0f;
+    float          horizontal_transfer = 0.0f;
+    int            dispersion_rate     = 0;
+};
+
+pixel_properties get_pixel_properties(pixel_type type);
 
 struct pixel
 {
-    pixel_data data;
-    glm::vec4  colour;
-    bool       updated_this_frame = false;
+    pixel_type type;
 
-    template <typename... Ts>
-    auto is() const -> bool { return (std::holds_alternative<Ts>(data) || ...); }
-
-    template <typename T>
-    auto as() -> T& { return std::get<T>(data); }
-
-    template <typename T>
-    auto as() const -> const T& { return std::get<T>(data); }
+    glm::vec4 colour;
+    glm::vec2 velocity           = {0.0, 0.0};
+    bool      is_falling         = false;
+    bool      updated_this_frame = false;
 
     static auto air() -> pixel;
     static auto sand() -> pixel;

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -4,6 +4,9 @@
 
 namespace sand {
 
+struct pixel;
+using affect_neighbour_func = void(*)(pixel& me, pixel& them);
+
 enum class pixel_movement : std::uint8_t
 {
     none,
@@ -15,13 +18,14 @@ enum class pixel_movement : std::uint8_t
 
 enum class pixel_type : std::uint8_t
 {
-    none  = 0,
-    sand  = 1,
-    dirt  = 2,
-    coal  = 3,
-    water = 4,
-    lava  = 5,
-    rock  = 6,
+    none,
+    sand,
+    dirt,
+    coal,
+    water,
+    lava,
+    rock,
+    steam,
 };
 
 struct pixel_properties
@@ -30,6 +34,8 @@ struct pixel_properties
     float          inertial_resistance = 0.0f;
     float          horizontal_transfer = 0.0f;
     int            dispersion_rate     = 0;
+
+    affect_neighbour_func affect_neighbour = [](pixel& me, pixel& them) {};
 };
 
 pixel_properties get_pixel_properties(pixel_type type);
@@ -50,6 +56,7 @@ struct pixel
     static auto rock() -> pixel;
     static auto water() -> pixel;
     static auto lava() -> pixel;
+    static auto steam() -> pixel;
 };
 
 }

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -33,6 +33,7 @@ struct editor
         { "water", sand::pixel::water },
         { "lava",  sand::pixel::lava  },
         { "rock",  sand::pixel::rock  },
+        { "steam", sand::pixel::steam },
     };
 
     float brush_size = 5.0f;

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -17,28 +17,30 @@ auto below(glm::ivec2 pos) -> glm::ivec2
     return pos + glm::ivec2{0, 1};
 }
 
-auto can_pixel_move_to(const tile& pixels, glm::ivec2 src, glm::ivec2 dst) -> bool
+auto can_pixel_move_to(const tile& pixels, glm::ivec2 src_pos, glm::ivec2 dst_pos) -> bool
 {
-    if (!tile::valid(src) || !tile::valid(dst)) { return false; }
+    if (!tile::valid(src_pos) || !tile::valid(dst_pos)) { return false; }
 
-    const auto& from      = pixels.at(src);
-    const auto from_props = get_pixel_properties(from.type);
-    const auto& to        = pixels.at(dst);
-    const auto to_props   = get_pixel_properties(to.type);
+    const auto src = get_pixel_properties(pixels.at(src_pos).type).movement;
+    const auto dst = get_pixel_properties(pixels.at(dst_pos).type).movement;
 
-    if (from_props.movement == pixel_movement::movable_solid) {
-        return to_props.movement == pixel_movement::none
-            || to_props.movement == pixel_movement::liquid;
+    using enum pixel_movement;
+    switch (src) {
+        case movable_solid:
+            return dst == none
+                || dst == liquid
+                || dst == gas;
+
+        case liquid:
+            return dst == none;
+
+        case gas:
+            return dst == none
+                || dst == liquid;
+
+        default:
+            return false;
     }
-    else if (from_props.movement == pixel_movement::liquid) {
-        return to_props.movement == pixel_movement::none;
-    }
-    else if (from_props.movement == pixel_movement::gas) {
-        return to_props.movement == pixel_movement::none
-            || to_props.movement == pixel_movement::liquid
-            || to_props.movement == pixel_movement::movable_solid;
-    }
-    return false;
 }
 
 auto set_adjacent_free_falling(tile& pixels, glm::ivec2 pos) -> void

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -167,6 +167,11 @@ auto update_movable_solid(tile& pixels, glm::ivec2 pos, const world_settings& se
 
 auto update_liquid(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt) -> void
 {
+    const auto scope = scope_exit{[&] {
+        auto& pixel = pixels.at(pos);
+        affect_neighbours(pixels, pos);
+    }};
+
     auto& data = pixels.at(pos);
     const auto props = get_pixel_properties(data.type);
     auto& vel = data.velocity;

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -204,12 +204,10 @@ auto update_movable_solid(tile& pixels, glm::ivec2 pos, const world_settings& se
 
 auto update_liquid(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt) -> glm::ivec2
 {
-    auto& data = pixels.at(pos);
-    const auto props = get_pixel_properties(data.type);
-    auto& vel = data.velocity;
+    auto& vel = pixels.at(pos).velocity;
     vel += settings.gravity * (float)dt;
-    auto offset = glm::ivec2{0, glm::max(1, (int)vel.y)};
     
+    const auto offset = glm::ivec2{0, glm::max(1, (int)vel.y)};
     if (const auto new_pos = move_towards(pixels, pos, offset); new_pos != pos) {
         return new_pos;
     }
@@ -219,15 +217,10 @@ auto update_liquid(tile& pixels, glm::ivec2 pos, const world_settings& settings,
 
 auto update_gas(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt) -> glm::ivec2
 {
-    static std::random_device rd;
-    static std::mt19937 g(rd());
-
-    auto& data = pixels.at(pos);
-    const auto props = get_pixel_properties(data.type);
-    auto& vel = data.velocity;
+    auto& vel = pixels.at(pos).velocity;
     vel -= settings.gravity * (float)dt;
-    auto offset = glm::ivec2{0, glm::min(-1, (int)vel.y)};
 
+    const auto offset = glm::ivec2{0, glm::min(-1, (int)vel.y)};
     if (const auto new_pos = move_towards(pixels, pos, offset); new_pos != pos) {
         return new_pos;
     }

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -149,12 +149,7 @@ auto update_movable_solid(tile& pixels, glm::ivec2 pos, const world_settings& se
 {
     const auto original_pos = pos;
     const auto scope = scope_exit{[&] {
-        auto& pixel = pixels.at(pos);
-        if (pos != original_pos) {
-            pixel.is_falling = true;
-        } else {
-            pixel.is_falling = false;
-        }
+        pixels.at(pos).is_falling = pos != original_pos;
     }};
 
     // Apply gravity if can move down
@@ -182,14 +177,8 @@ auto update_movable_solid(tile& pixels, glm::ivec2 pos, const world_settings& se
     }
 
     if (!pixels.at(pos).updated_this_frame && pixels.at(pos).is_falling) {
-        auto offsets = std::array{
-            glm::ivec2{-1, 1},
-            glm::ivec2{1, 1},
-        };
-
-        if (rand() % 2) {
-            std::swap(offsets[0], offsets[1]);
-        }
+        auto offsets = std::array{ glm::ivec2{-1, 1}, glm::ivec2{1, 1}, };
+        if (coin_flip()) std::swap(offsets[0], offsets[1]);
 
         for (auto offset : offsets) {
             pos = move_towards(pixels, pos, offset);

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -243,16 +243,18 @@ auto update_pixel(tile& pixels, glm::ivec2 pos, const world_settings& settings, 
     auto& pixel = pixels.at(pos);
     const auto props = get_pixel_properties(pixel.type);
 
-    if (props.movement == pixel_movement::movable_solid) {
-        pos = update_movable_solid(pixels, pos, settings, dt);
-    }
-    else if (props.movement == pixel_movement::liquid) {
-        pos = update_liquid(pixels, pos, settings, dt);
-    }
-    else if (props.movement == pixel_movement::gas) {
-        pos = update_gas(pixels, pos, settings, dt);
-    } else {
-        return;
+    switch (props.movement) {
+        break; case pixel_movement::movable_solid:
+            pos = update_movable_solid(pixels, pos, settings, dt);
+
+        break; case pixel_movement::liquid:
+            pos = update_liquid(pixels, pos, settings, dt);
+
+        break; case pixel_movement::gas:
+            pos = update_gas(pixels, pos, settings, dt);
+            
+        break; default:
+            return;
     }
 
     affect_neighbours(pixels, pos);

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -25,18 +25,17 @@ auto can_pixel_move_to(const tile& pixels, glm::ivec2 src_pos, glm::ivec2 dst_po
     const auto dst = get_pixel_properties(pixels.at(dst_pos).type).movement;
 
     using enum pixel_movement;
+
+    // If the destination is empty, we can always move there
+    if (dst == none) return true;
+
     switch (src) {
         case movable_solid:
-            return dst == none
-                || dst == liquid
-                || dst == gas;
-
-        case liquid:
-            return dst == none;
+            return dst == liquid // solids can sink into liquid
+                || dst == gas;   // solids can displace gas
 
         case gas:
-            return dst == none
-                || dst == liquid;
+            return dst == liquid; // gas can bubble up through a liquid
 
         default:
             return false;

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -19,10 +19,10 @@ auto can_pixel_move_to(const tile& pixels, glm::ivec2 src, glm::ivec2 dst) -> bo
 {
     if (!tile::valid(src) || !tile::valid(dst)) { return false; }
 
-    const auto& from = pixels.at(src);
+    const auto& from      = pixels.at(src);
     const auto from_props = get_pixel_properties(from.type);
-    const auto& to   = pixels.at(dst);
-    const auto to_props = get_pixel_properties(to.type);
+    const auto& to        = pixels.at(dst);
+    const auto to_props   = get_pixel_properties(to.type);
 
     if (from_props.movement == pixel_movement::movable_solid) {
         return to_props.movement == pixel_movement::none || to_props.movement == pixel_movement::liquid;
@@ -39,17 +39,17 @@ auto set_adjacent_free_falling(tile& pixels, glm::ivec2 pos) -> void
     const auto r = pos + glm::ivec2{1, 0};
 
     if (pixels.valid(l)) {
-        const auto props = get_pixel_properties(pixels.at(l).type);
+        auto& px = pixels.at(l);
+        const auto props = get_pixel_properties(px.type);
         if (props.movement == pixel_movement::movable_solid) {
-            auto& px = pixels.at(l);
             px.is_falling = random_from_range(0.0f, 1.0f) > props.inertial_resistance || px.is_falling;
         }
     }
 
     if (pixels.valid(r)) {
-        const auto props = get_pixel_properties(pixels.at(r).type);
+        auto& px = pixels.at(r);
+        const auto props = get_pixel_properties(px.type);
         if (props.movement == pixel_movement::movable_solid) {
-            auto& px = pixels.at(r);
             px.is_falling = random_from_range(0.0f, 1.0f) > props.inertial_resistance || px.is_falling;
         }
     }

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -4,6 +4,8 @@
 #include <array>
 #include <utility>
 #include <variant>
+#include <algorithm>
+#include <random>
 
 #include <glm/glm.hpp>
 
@@ -185,10 +187,8 @@ auto update_liquid(tile& pixels, glm::ivec2 pos, const world_settings& settings,
         glm::ivec2{props.dispersion_rate, 0}
     };
 
-    if (rand() % 2) {
-        std::swap(offsets[0], offsets[1]);
-        std::swap(offsets[2], offsets[3]);
-    }
+    if (coin_flip()) std::swap(offsets[0], offsets[1]);
+    if (coin_flip()) std::swap(offsets[2], offsets[3]);
 
     for (auto offset : offsets) {
         if (offset.y == 0) {
@@ -204,12 +204,15 @@ auto update_liquid(tile& pixels, glm::ivec2 pos, const world_settings& settings,
 
 auto update_gas(tile& pixels, glm::ivec2 pos, const world_settings& settings, double dt) -> glm::ivec2
 {
+    static std::random_device rd;
+    static std::mt19937 g(rd());
+
     auto& data = pixels.at(pos);
     const auto props = get_pixel_properties(data.type);
     auto& vel = data.velocity;
-    vel += settings.gravity * (float)dt;
+    vel -= settings.gravity * (float)dt;
     auto offset = glm::ivec2{0, glm::min(-1, (int)vel.y)};
-    
+
     if (const auto new_pos = move_towards(pixels, pos, offset); new_pos != pos) {
         return new_pos;
     }
@@ -221,10 +224,8 @@ auto update_gas(tile& pixels, glm::ivec2 pos, const world_settings& settings, do
         glm::ivec2{props.dispersion_rate, 0}
     };
 
-    if (rand() % 2) {
-        std::swap(offsets[0], offsets[1]);
-        std::swap(offsets[2], offsets[3]);
-    }
+    if (coin_flip()) std::swap(offsets[0], offsets[1]);
+    if (coin_flip()) std::swap(offsets[2], offsets[3]);
 
     for (auto offset : offsets) {
         if (offset.y == 0) {
@@ -252,7 +253,7 @@ auto update_pixel(tile& pixels, glm::ivec2 pos, const world_settings& settings, 
 
         break; case pixel_movement::gas:
             pos = update_gas(pixels, pos, settings, dt);
-            
+
         break; default:
             return;
     }


### PR DESCRIPTION
* Remove the variant based implementation of pixels.
* Have a enum for `pixel_type` as well as an enum to describe pixel movement with `pixel_movement`.
* Pixel specific constants such as `dispersion_rate` now lives outside the pixel, making the pixels much smaller and simpler.
* The `pixel_properties` for each pixel type also contain the `pixel_movement`.
* Added `steam` as an example of a gas and setup their movement.
* Added an `affect_neighbour` function pointer to the pixel properties which gets calls on the neighbours of a pixel after it moves.
* Implemented `affect_neighbour` for lava to turn water into steam on contact.