### PR TITLE
Remove neighbour affect function from `pixel_properties`

### DIFF
--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -71,14 +71,10 @@ auto pixel::properties() const -> const pixel_properties&
             static constexpr auto px = pixel_properties{
                 .movement = pixel_movement::liquid,
                 .dispersion_rate = 1,
+                .can_boil_water = true,
                 .corrosion_resist = 1.0f,
                 .is_burn_source = true,
-                .is_ember_source = true,
-                .affect_neighbour = [](pixel& me, pixel& them) {
-                    if (them.type == pixel_type::water) {
-                        them = pixel::steam();
-                    }
-                },
+                .is_ember_source = true
             };
             return px;
         }

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -30,7 +30,7 @@ auto pixel::properties() const -> const pixel_properties&
         }
         case pixel_type::sand: {
             static constexpr auto px = pixel_properties{
-                .movement = pixel_movement::movable_solid,
+                .movement = pixel_movement::solid,
                 .inertial_resistance = 0.1f,
                 .horizontal_transfer = 0.3f,
                 .corrosion_resist = 0.3f
@@ -39,7 +39,7 @@ auto pixel::properties() const -> const pixel_properties&
         }
         case pixel_type::dirt: {
             static constexpr auto px = pixel_properties{
-                .movement = pixel_movement::movable_solid,
+                .movement = pixel_movement::solid,
                 .inertial_resistance = 0.4f,
                 .horizontal_transfer = 0.2f,
                 .corrosion_resist = 0.5f
@@ -48,7 +48,7 @@ auto pixel::properties() const -> const pixel_properties&
         }
         case pixel_type::coal: {
             static constexpr auto px = pixel_properties{
-                .movement = pixel_movement::movable_solid,
+                .movement = pixel_movement::solid,
                 .inertial_resistance = 0.95f,
                 .horizontal_transfer = 0.1f,
                 .corrosion_resist = 0.8f,
@@ -89,14 +89,14 @@ auto pixel::properties() const -> const pixel_properties&
         }
         case pixel_type::rock: {
             static constexpr auto px = pixel_properties{
-                .movement = pixel_movement::immovable_solid,
+                .movement = pixel_movement::none,
                 .corrosion_resist = 0.95f
             };
             return px;
         }
         case pixel_type::titanium: {
             static constexpr auto px = pixel_properties{
-                .movement = pixel_movement::immovable_solid,
+                .movement = pixel_movement::none,
                 .corrosion_resist = 1.0f
             };
             return px;
@@ -111,7 +111,7 @@ auto pixel::properties() const -> const pixel_properties&
         }
         case pixel_type::fuse: {
             static constexpr auto px = pixel_properties{
-                .movement = pixel_movement::immovable_solid,
+                .movement = pixel_movement::none,
                 .corrosion_resist = 0.1f,
                 .flammability = 0.25f,
                 .put_out_surrounded = 0.0f,

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -87,13 +87,7 @@ auto pixel::properties() const -> const pixel_properties&
                 .movement = pixel_movement::liquid,
                 .dispersion_rate = 1,
                 .corrosion_resist = 1.0f,
-                .affect_neighbour = [](pixel& me, pixel& them) {
-                    const auto& props = them.properties();
-                    if (random_from_range(0.0f, 1.0f) > props.corrosion_resist) {
-                        them = pixel::air();
-                        if (random_from_range(0.0f, 1.0f) > 0.9f) me = pixel::air();
-                    }
-                }
+                .is_corrosion_source = true
             };
             return px;
         }

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -6,9 +6,6 @@
 
 namespace sand {
 
-struct pixel;
-using affect_neighbour_func = void(*)(pixel& me, pixel& them);
-
 enum class pixel_movement : std::uint8_t
 {
     none,
@@ -56,9 +53,6 @@ struct pixel_properties
     float          burn_out_chance     = 0.0f; // Chance that the pixel gets destroyed
     bool           is_burn_source      = false; // Can this pixel cause others to burn?
     bool           is_ember_source     = false; // Does this pixel produce embers?
-
-    // Called on each of the pixels neighers (TODO: Remove, rely only on property specific logic)
-    affect_neighbour_func affect_neighbour = [](pixel& me, pixel& them) {};
 };
 
 struct pixel

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -42,6 +42,9 @@ struct pixel_properties
     float          horizontal_transfer = 0.0f;
     int            dispersion_rate     = 0;
 
+    // Water Controls
+    bool           can_boil_water      = false;
+
     // Acid Controls
     float          corrosion_resist    = 0.8f;
     bool           is_corrosion_source = false; // Can this pixel type corrode others?

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -9,8 +9,7 @@ namespace sand {
 enum class pixel_movement : std::uint8_t
 {
     none,
-    immovable_solid,
-    movable_solid,
+    solid,
     liquid,
     gas,
 };

--- a/src/pixel.h
+++ b/src/pixel.h
@@ -44,6 +44,7 @@ struct pixel_properties
 
     // Acid Controls
     float          corrosion_resist    = 0.8f;
+    bool           is_corrosion_source = false; // Can this pixel type corrode others?
 
     // Fire Controls
     float          flammability        = 0.0f; // Chance that is_burning = true from neighbour

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -117,13 +117,24 @@ auto affect_neighbours(tile& pixels, glm::ivec2 pos) -> void
             props.affect_neighbour(pixel, neighbour);
 
             // Do property-specific logic
-            // 1) Flammability spreads
+            // 1) Corrode neighbours
+            if (props.is_corrosion_source) {
+                if (random_from_range(0.0f, 1.0f) > neighbour.properties().corrosion_resist) {
+                    neighbour = pixel::air();
+                    if (random_from_range(0.0f, 1.0f) > 0.9f) {
+                        pixel = pixel::air();
+                    }
+                }
+            }
+            
+            // 2) Spread fire
             if (props.is_burn_source || pixel.is_burning) {
                 if (random_from_range(0.0f, 1.0f) < neighbour.properties().flammability) {
                     neighbour.is_burning = true;
                 }
             }
 
+            // 3) Produce embers
             if (can_produce_embers && neighbour.type == pixel_type::none) {
                 if (random_from_range(0.0f, 1.0f) < 0.01f) {
                     neighbour = pixel::ember();

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -31,11 +31,11 @@ auto can_pixel_move_to(const tile& pixels, glm::ivec2 src_pos, glm::ivec2 dst_po
     using pm = pixel_movement;
     switch (src) {
         case pm::solid:
-            return dst == pm::liquid // solids can sink into liquid
-                || dst == pm::gas;   // solids can displace gas
+            return dst == pm::liquid
+                || dst == pm::gas;
 
-        case pm::gas:
-            return dst == pm::liquid; // gas can bubble up through a liquid
+        case pm::liquid:
+            return dst == pm::gas;
 
         default:
             return false;

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -113,10 +113,6 @@ auto affect_neighbours(tile& pixels, glm::ivec2 pos) -> void
         if (pixels.valid(pos + offset)) {
             auto& neighbour = pixels.at(pos + offset);
 
-            // Do pixel-type-specific logic
-            props.affect_neighbour(pixel, neighbour);
-
-            // Do property-specific logic
             // 1) Boil water
             if (props.can_boil_water) {
                 if (neighbour.type == pixel_type::water) {
@@ -309,7 +305,7 @@ auto update_pixel(tile& pixels, glm::ivec2 pos) -> void
         } break;
 
         default: {
-            return;
+            
         } break;
     }
 

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -22,16 +22,15 @@ auto can_pixel_move_to(const tile& pixels, glm::ivec2 src_pos, glm::ivec2 dst_po
 {
     if (!tile::valid(src_pos) || !tile::valid(dst_pos)) { return false; }
 
+    // If the destination is empty, we can always move there
+    if (pixels.at(dst_pos).type == pixel_type::none) { return true; }
+
     const auto& src = pixels.at(src_pos).properties().movement;
     const auto& dst = pixels.at(dst_pos).properties().movement;
 
     using pm = pixel_movement;
-
-    // If the destination is empty, we can always move there
-    if (dst == pm::none) return true;
-
     switch (src) {
-        case pm::movable_solid:
+        case pm::solid:
             return dst == pm::liquid // solids can sink into liquid
                 || dst == pm::gas;   // solids can displace gas
 
@@ -51,7 +50,7 @@ auto set_adjacent_free_falling(tile& pixels, glm::ivec2 pos) -> void
     if (pixels.valid(l)) {
         auto& px = pixels.at(l);
         const auto& props = px.properties();
-        if (px.properties().movement == pixel_movement::movable_solid) {
+        if (px.properties().movement == pixel_movement::solid) {
             px.is_falling = random_from_range(0.0f, 1.0f) > props.inertial_resistance || px.is_falling;
         }
     }
@@ -59,7 +58,7 @@ auto set_adjacent_free_falling(tile& pixels, glm::ivec2 pos) -> void
     if (pixels.valid(r)) {
         auto& px = pixels.at(r);
         const auto& props = px.properties();
-        if (props.movement == pixel_movement::movable_solid) {
+        if (props.movement == pixel_movement::solid) {
             px.is_falling = random_from_range(0.0f, 1.0f) > props.inertial_resistance || px.is_falling;
         }
     }
@@ -288,7 +287,7 @@ auto update_pixel(tile& pixels, glm::ivec2 pos) -> void
     }
 
     switch (pixels.at(pos).properties().movement) {
-        case pixel_movement::movable_solid: {
+        case pixel_movement::solid: {
             pos = update_movable_solid(pixels, pos);
         } break;
 
@@ -300,12 +299,8 @@ auto update_pixel(tile& pixels, glm::ivec2 pos) -> void
             pos = update_gas(pixels, pos);
         } break;
 
-        case pixel_movement::immovable_solid: {
-            
-        } break;
-
         default: {
-            
+
         } break;
     }
 

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -117,7 +117,14 @@ auto affect_neighbours(tile& pixels, glm::ivec2 pos) -> void
             props.affect_neighbour(pixel, neighbour);
 
             // Do property-specific logic
-            // 1) Corrode neighbours
+            // 1) Boil water
+            if (props.can_boil_water) {
+                if (neighbour.type == pixel_type::water) {
+                    neighbour = pixel::steam();
+                }
+            }
+
+            // 2) Corrode neighbours
             if (props.is_corrosion_source) {
                 if (random_from_range(0.0f, 1.0f) > neighbour.properties().corrosion_resist) {
                     neighbour = pixel::air();
@@ -127,14 +134,14 @@ auto affect_neighbours(tile& pixels, glm::ivec2 pos) -> void
                 }
             }
             
-            // 2) Spread fire
+            // 3) Spread fire
             if (props.is_burn_source || pixel.is_burning) {
                 if (random_from_range(0.0f, 1.0f) < neighbour.properties().flammability) {
                     neighbour.is_burning = true;
                 }
             }
 
-            // 3) Produce embers
+            // 4) Produce embers
             if (can_produce_embers && neighbour.type == pixel_type::none) {
                 if (random_from_range(0.0f, 1.0f) < 0.01f) {
                     neighbour = pixel::ember();


### PR DESCRIPTION
* Remove the `affect_neighbour_func` from pixel properties. Instead, we should set properties on the pixels and act upon those. Then there is no logic tied to specific pixel types, only properties.
* Added `can_boil_water` bool to `pixel_properties`. Pixels with this set turn water neighbours into steam.
* Added `is_corrosion_source` bool to `pixel_properties`. Pixels with this will try to corrode their neighbours.
* `lava` has `can_boil_water` set to true.
* `acid` has `is_corrosion_source` set to true.
* Remove `immovable_solid` from `pixel_movement` and rename `movable_solid` to `solid`. Those that were previously `immovable_solid` now just have `none` set for their movement. We previously had to make the distinction because before the movement types described the entire pixel, and we could not distinguish between immovable solids and empty pixels. Now that these are just a movement property and each pixel has a concrete type, we can tell if a pixel is `none` without checking movement.