### PR TITLE
Update Tile in Chunks

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -9,7 +9,7 @@ Size=476,528
 Collapsed=1
 
 [Window][Editor]
-Pos=842,127
+Pos=843,120
 Size=361,436
 Collapsed=0
 

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -177,7 +177,7 @@ auto main() -> int
         
         if (left_mouse_down) {
             const auto coord = random_from_circle(editor.brush_size)
-                             + glm::ivec2((sand::tile_size_f / size) * window.get_mouse_pos());
+                             + glm::ivec2(((float)sand::tile_size / size) * window.get_mouse_pos());
             if (tile->valid(coord)) {
                 tile->set(coord, editor.get_pixel());
             }

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -53,6 +53,7 @@ struct editor
         return pixel_makers[current].second();
     }
 };
+
 auto main() -> int
 {
     using namespace sand;

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -143,6 +143,7 @@ auto main() -> int
             }
 
             ImGui::Text("FPS: %d", timer.frame_rate());
+            ImGui::Text("Awake chunks: %d", tile->num_awake_chunks());
 
             if (ImGui::Button("Save")) {
                 auto file = std::ofstream{"save.bin", std::ios::binary};
@@ -154,6 +155,7 @@ auto main() -> int
                 auto file = std::ifstream{"save.bin", std::ios::binary};
                 auto archive = cereal::BinaryInputArchive{file};
                 archive(*tile);
+                tile->wake_all_chunks();
             }
         }
         ImGui::End();

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -45,30 +45,6 @@ auto tile::valid(glm::ivec2 pos) -> bool
     return 0 <= pos.x && pos.x < tile_size && 0 <= pos.y && pos.y < tile_size;
 }
 
-auto tile::simulate_chunk(glm::ivec2 chunk) -> void
-{
-    const auto inner = [&] (std::uint32_t x, std::uint32_t y) {
-        if (!at({x, y}).is_updated) {
-            update_pixel(*this, {x, y});
-        }
-    };
-
-    for (std::uint32_t y = chunk_size * (chunk.y + 1); y != chunk_size * chunk.y; ) {
-        --y;
-        if (coin_flip()) {
-            for (std::uint32_t x = chunk_size * chunk.x; x != chunk_size * (chunk.x + 1); ++x) {
-                inner(x, y);
-            }
-        }
-        else {
-            for (std::uint32_t x = chunk_size * (chunk.x + 1); x != chunk_size * chunk.x; ) {
-                --x;
-                inner(x, y);
-            }
-        }
-    }
-}
-
 auto tile::simulate() -> void
 {
     for (auto& chunk : d_chunks) {
@@ -76,24 +52,21 @@ auto tile::simulate() -> void
         chunk.should_step_next = false;
     }
     
-    const auto inner = [&] (std::uint32_t x, std::uint32_t y) {
-        const auto pos = glm::ivec2{x, y};
+    const auto inner = [&] (glm::ivec2 pos) {
         if (is_chunk_awake(pos) && !at(pos).is_updated) {
             update_pixel(*this, pos);
         }
     };
 
-    for (std::uint32_t y = tile_size; y != 0; ) {
-        --y;
+    for (std::uint32_t y = tile_size; y != 0; --y) {
         if (coin_flip()) {
             for (std::uint32_t x = 0; x != tile_size; ++x) {
-                inner(x, y);
+                inner({x, y - 1});
             }
         }
         else {
-            for (std::uint32_t x = tile_size; x != 0; ) {
-                --x;
-                inner(x, y);
+            for (std::uint32_t x = tile_size; x != 0; --x) {
+                inner({x - 1, y - 1});
             }
         }
     }

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -76,21 +76,24 @@ auto tile::simulate() -> void
         chunk.should_step_next = false;
     }
     
-    for (std::uint32_t y = num_chunks; y != 0; ) {
+    const auto inner = [&] (std::uint32_t x, std::uint32_t y) {
+        const auto pos = glm::ivec2{x, y};
+        if (is_chunk_awake(pos) && !at(pos).is_updated) {
+            update_pixel(*this, pos);
+        }
+    };
+
+    for (std::uint32_t y = tile_size; y != 0; ) {
         --y;
         if (coin_flip()) {
-            for (std::uint32_t x = 0; x != num_chunks; ++x) {
-                if (d_chunks[get_chunk_pos(glm::ivec2{x, y})].should_step) {
-                    simulate_chunk({x, y});
-                }
+            for (std::uint32_t x = 0; x != tile_size; ++x) {
+                inner(x, y);
             }
         }
         else {
-            for (std::uint32_t x = num_chunks; x != 0; ) {
+            for (std::uint32_t x = tile_size; x != 0; ) {
                 --x;
-                if (d_chunks[get_chunk_pos(glm::ivec2{x, y})].should_step) {
-                    simulate_chunk({x, y});
-                }
+                inner(x, y);
             }
         }
     }
@@ -187,6 +190,12 @@ auto tile::num_awake_chunks() const -> std::size_t
         count += static_cast<std::size_t>(chunk.should_step);
     }
     return count;
+}
+
+auto tile::is_chunk_awake(glm::ivec2 pixel) const -> bool
+{
+    const auto chunk = pixel / static_cast<int>(chunk_size);
+    return d_chunks[get_chunk_pos(chunk)].should_step;
 }
 
 }

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -143,6 +143,50 @@ auto tile::wake_chunk_with_pixel(glm::ivec2 pixel) -> void
 {
     const auto chunk = pixel / static_cast<int>(chunk_size);
     d_chunks[get_chunk_pos(chunk)].should_step_next = true;
+
+    // Wake right
+    if (pixel.x != tile_size - 1 && pixel.x + 1 % chunk_size == 0)
+    {
+        const auto neighbour = chunk + glm::ivec2{1, 0};
+        d_chunks[get_chunk_pos(neighbour)].should_step_next = true;
+    }
+
+    // Wake left
+    if (pixel.x != 0 && pixel.x - 1 % chunk_size == 0)
+    {
+        const auto neighbour = chunk - glm::ivec2{1, 0};
+        d_chunks[get_chunk_pos(neighbour)].should_step_next = true;
+    }
+
+    // Wake down
+    if (pixel.y != tile_size - 1 && pixel.y + 1 % chunk_size == 0)
+    {
+        const auto neighbour = chunk + glm::ivec2{0, 1};
+        d_chunks[get_chunk_pos(neighbour)].should_step_next = true;
+    }
+
+    // Wake up
+    if (pixel.y != 0 && pixel.y - 1 % chunk_size == 0)
+    {
+        const auto neighbour = chunk - glm::ivec2{0, 1};
+        d_chunks[get_chunk_pos(neighbour)].should_step_next = true;
+    }
+}
+
+auto tile::wake_all_chunks() -> void
+{
+    for (auto& chunk : d_chunks) {
+        chunk.should_step_next = true;
+    }
+}
+
+auto tile::num_awake_chunks() const -> std::size_t
+{
+    auto count = std::size_t{0};
+    for (const auto& chunk : d_chunks) {
+        count += static_cast<std::size_t>(chunk.should_step);
+    }
+    return count;
 }
 
 }

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -126,7 +126,36 @@ auto tile::swap(glm::ivec2 lhs, glm::ivec2 rhs) -> glm::ivec2
 
 auto tile::wake_chunk_with_pixel(glm::ivec2 pixel) -> void
 {
-    d_to_update.emplace(pixel / 16);
+    const auto chunk = pixel / static_cast<int>(chunk_size);
+    d_to_update.emplace(chunk);
+
+    // Wake right
+    if (pixel.x != tile_size - 1 && pixel.x + 1 % chunk_size == 0)
+    {
+        const auto right = chunk + glm::ivec2{1, 0};
+        d_to_update.emplace(right);
+    }
+
+    // Wake left
+    if (pixel.x != 0 && pixel.x - 1 % chunk_size == 0)
+    {
+        const auto left = chunk - glm::ivec2{1, 0};
+        d_to_update.emplace(left);
+    }
+
+    // Wake down
+    if (pixel.y != tile_size - 1 && pixel.y + 1 % chunk_size == 0)
+    {
+        const auto down = chunk + glm::ivec2{0, 1};
+        d_to_update.emplace(down);
+    }
+
+    // Wake up
+    if (pixel.y != 0 && pixel.y - 1 % chunk_size == 0)
+    {
+        const auto up = chunk - glm::ivec2{0, 1};
+        d_to_update.emplace(up);
+    }
 }
 
 }

--- a/src/tile.h
+++ b/src/tile.h
@@ -25,8 +25,8 @@ static constexpr std::uint32_t num_chunks = tile_size / chunk_size;
 
 struct chunk
 {
-    bool should_step      = false;
-    bool should_step_next = false;
+    bool should_step      = true;
+    bool should_step_next = true;
 };
 
 class tile
@@ -62,6 +62,8 @@ public:
 
     // Coord of a pixel, not a chunk. If on a boundary, will wake adjacent chunk
     auto wake_chunk_with_pixel(glm::ivec2 pixel) -> void;
+    auto wake_all_chunks() -> void;
+    auto num_awake_chunks() const -> std::size_t;
 
     auto data() const -> const buffer& { return d_buffer; }
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -19,19 +19,28 @@ static constexpr float         tile_size_f = static_cast<float>(tile_size);
 static constexpr std::uint32_t chunk_size   = 16;
 static constexpr float         chunk_size_f = static_cast<float>(chunk_size);
 
+static_assert(tile_size % chunk_size == 0);
+
+static constexpr std::uint32_t num_chunks = tile_size / chunk_size;
+
+struct chunk
+{
+    bool should_step      = false;
+    bool should_step_next = false;
+};
+
 class tile
 {
 public:
     using buffer = std::array<glm::vec4, tile_size * tile_size>;
     using pixels = std::array<pixel, tile_size * tile_size>;
+    using chunks = std::array<chunk, num_chunks * num_chunks>;
 
 private:
-    buffer        d_buffer;
-    pixels        d_pixels;
+    buffer d_buffer;
+    pixels d_pixels;
 
-    // Simulate Data Structures (stored here so we dont need to allocate each time)
-    std::unordered_set<glm::ivec2> d_to_update;
-    std::unordered_set<glm::ivec2> d_updated;
+    chunks d_chunks;
     auto simulate_chunk(glm::ivec2 chunk) -> void;
 
 public:

--- a/src/tile.h
+++ b/src/tile.h
@@ -3,14 +3,21 @@
 #include "serialise.hpp"
 
 #include <cstdint>
+#include <unordered_set>
 #include <array>
 
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/glm.hpp>
+#include <glm/gtx/hash.hpp>
+
 
 namespace sand {
 
-static constexpr std::uint32_t tile_size = 256;
-static constexpr float         tile_size_f = static_cast<double>(tile_size);
+static constexpr std::uint32_t tile_size   = 256;
+static constexpr float         tile_size_f = static_cast<float>(tile_size);
+
+static constexpr std::uint32_t chunk_size   = 16;
+static constexpr float         chunk_size_f = static_cast<float>(chunk_size);
 
 class tile
 {
@@ -21,6 +28,11 @@ public:
 private:
     buffer        d_buffer;
     pixels        d_pixels;
+
+    // Simulate Data Structures (stored here so we dont need to allocate each time)
+    std::unordered_set<glm::ivec2> d_to_update;
+    std::unordered_set<glm::ivec2> d_updated;
+    auto simulate_chunk(glm::ivec2 chunk) -> void;
 
 public:
     tile();
@@ -38,6 +50,9 @@ public:
 
     // Returns the rhs
     auto swap(glm::ivec2 lhs, glm::ivec2 rhs) -> glm::ivec2;
+
+    // Coord of a pixel, not a chunk. If on a boundary, will wake adjacent chunk
+    auto wake_chunk_with_pixel(glm::ivec2 pixel) -> void;
 
     auto data() const -> const buffer& { return d_buffer; }
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -64,6 +64,7 @@ public:
     auto wake_chunk_with_pixel(glm::ivec2 pixel) -> void;
     auto wake_all_chunks() -> void;
     auto num_awake_chunks() const -> std::size_t;
+    auto is_chunk_awake(glm::ivec2 pixel) const -> bool;
 
     auto data() const -> const buffer& { return d_buffer; }
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -12,8 +12,8 @@
 
 namespace sand {
 
-static constexpr std::uint32_t tile_size   = 256;
-static constexpr std::uint32_t chunk_size   = 16;
+static constexpr std::uint32_t tile_size  = 256;
+static constexpr std::uint32_t chunk_size = 16;
 static_assert(tile_size % chunk_size == 0);
 
 static constexpr std::uint32_t num_chunks = tile_size / chunk_size;

--- a/src/tile.h
+++ b/src/tile.h
@@ -10,15 +10,10 @@
 #include <glm/glm.hpp>
 #include <glm/gtx/hash.hpp>
 
-
 namespace sand {
 
 static constexpr std::uint32_t tile_size   = 256;
-static constexpr float         tile_size_f = static_cast<float>(tile_size);
-
 static constexpr std::uint32_t chunk_size   = 16;
-static constexpr float         chunk_size_f = static_cast<float>(chunk_size);
-
 static_assert(tile_size % chunk_size == 0);
 
 static constexpr std::uint32_t num_chunks = tile_size / chunk_size;
@@ -39,9 +34,7 @@ public:
 private:
     buffer d_buffer;
     pixels d_pixels;
-
     chunks d_chunks;
-    auto simulate_chunk(glm::ivec2 chunk) -> void;
 
 public:
     tile();
@@ -60,7 +53,7 @@ public:
     // Returns the rhs
     auto swap(glm::ivec2 lhs, glm::ivec2 rhs) -> glm::ivec2;
 
-    // Coord of a pixel, not a chunk. If on a boundary, will wake adjacent chunk
+    // Chunk API
     auto wake_chunk_with_pixel(glm::ivec2 pixel) -> void;
     auto wake_all_chunks() -> void;
     auto num_awake_chunks() const -> std::size_t;

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -86,7 +86,6 @@ auto move_towards(tile& pixels, glm::ivec2 from, glm::ivec2 offset) -> glm::ivec
 
     if (curr_pos != from) {
         pixels.at(curr_pos).is_updated = true;
-        pixels.wake_chunk_with_pixel(curr_pos);
     }
 
     return curr_pos;
@@ -119,7 +118,6 @@ auto affect_neighbours(tile& pixels, glm::ivec2 pos) -> void
             if (props.can_boil_water) {
                 if (neighbour.type == pixel_type::water) {
                     neighbour = pixel::steam();
-                    pixels.wake_chunk_with_pixel(neigh_pos);
                 }
             }
 
@@ -290,6 +288,14 @@ auto update_pixel(tile& pixels, glm::ivec2 pos) -> void
 {
     if (pixels.at(pos).type == pixel_type::none) {
         return;
+    }
+
+    // If a pixel is burning or falling, wake the chunk next frame
+    {
+        const auto& pixel = pixels.at(pos);
+        if (pixel.is_burning || pixel.is_falling) {
+            pixels.wake_chunk_with_pixel(pos);
+        }
     }
 
     switch (pixels.at(pos).properties().movement) {

--- a/src/update_functions.cpp
+++ b/src/update_functions.cpp
@@ -87,6 +87,7 @@ auto move_towards(tile& pixels, glm::ivec2 from, glm::ivec2 offset) -> glm::ivec
         pixels.at(curr_pos).is_updated = true;
     }
 
+    pixels.wake_chunk_with_pixel(curr_pos);
     return curr_pos;
 }
 

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <string>
 #include <span>
+#include <format>
 #include <glm/glm.hpp>
 
 namespace sand {


### PR DESCRIPTION
* Split the tile into chunks.
* When a pixel is placed in the world, or moves, or is burning, a flag is set to update all pixels in that chunk the next frame.
* When a chunk is not awake, all pixels inside it are not updated.
* Massively increases the fps. In the given save, fps has gone from 300 to 2200.